### PR TITLE
OTN Topology Update

### DIFF
--- a/YANG/ccamp/otn-topology/ietf-otn-topology.tree
+++ b/YANG/ccamp/otn-topology/ietf-otn-topology.tree
@@ -1,0 +1,558 @@
+
+module: ietf-otn-topology
+  augment /nw:networks/nw:network/nw:network-types/tet:te-topology:
+    +--rw otn-topology!
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes:
+    +--rw tsg?        identityref
+    +--rw distance?   uint32
+  augment /nw:networks/nw:network/nw:node/nt:termination-point/tet:te:
+    +--rw supported-payload-types* [index]
+       +--rw index           uint16
+       +--rw payload-type?   string
+  augment /nw:networks/nw:network/nw:node/nt:termination-point/tet:te/tet:interface-switching-capability/tet:max-lsp-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odu-type?   identityref
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:path-constraints/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odulist* [odu-type]
+             +--rw odu-type    identityref
+             +--rw number?     uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:path-constraints/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odulist* [odu-type]
+             +--rw odu-type    identityref
+             +--rw number?     uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:path-constraints/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro odulist* [odu-type]
+             +--ro odu-type    identityref
+             +--ro number?     uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:path-constraints/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro odulist* [odu-type]
+             +--ro odu-type    identityref
+             +--ro number?     uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:client-layer-adaptation/tet:switching-capability/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odulist* [odu-type]
+             +--rw odu-type    identityref
+             +--rw number?     uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:path-constraints/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odulist* [odu-type]
+             +--rw odu-type    identityref
+             +--rw number?     uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity/tet:path-constraints/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odulist* [odu-type]
+             +--rw odu-type    identityref
+             +--rw number?     uint16
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes/tet:interface-switching-capability/tet:max-lsp-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odu-type?   identityref
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes/tet:max-link-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odulist* [odu-type]
+             +--rw odu-type    identityref
+             +--rw number?     uint16
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes/tet:max-resv-link-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odulist* [odu-type]
+             +--rw odu-type    identityref
+             +--rw number?     uint16
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes/tet:unreserved-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odulist* [odu-type]
+             +--rw odu-type    identityref
+             +--rw number?     uint16
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:information-source-entry/tet:interface-switching-capability/tet:max-lsp-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro odu-type?   identityref
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:information-source-entry/tet:max-link-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro odulist* [odu-type]
+             +--ro odu-type    identityref
+             +--ro number?     uint16
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:information-source-entry/tet:max-resv-link-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro odulist* [odu-type]
+             +--ro odu-type    identityref
+             +--ro number?     uint16
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:information-source-entry/tet:unreserved-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro odulist* [odu-type]
+             +--ro odu-type    identityref
+             +--ro number?     uint16
+  augment /nw:networks/tet:te/tet:templates/tet:link-template/tet:te-link-attributes/tet:interface-switching-capability/tet:max-lsp-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odu-type?   identityref
+  augment /nw:networks/tet:te/tet:templates/tet:link-template/tet:te-link-attributes/tet:max-link-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odulist* [odu-type]
+             +--rw odu-type    identityref
+             +--rw number?     uint16
+  augment /nw:networks/tet:te/tet:templates/tet:link-template/tet:te-link-attributes/tet:max-resv-link-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odulist* [odu-type]
+             +--rw odu-type    identityref
+             +--rw number?     uint16
+  augment /nw:networks/tet:te/tet:templates/tet:link-template/tet:te-link-attributes/tet:unreserved-bandwidth/tet:te-bandwidth/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw odulist* [odu-type]
+             +--rw odu-type    identityref
+             +--rw number?     uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:label-restriction:
+    +--rw otn-label-restriction
+       +--rw range-type?   identityref
+       +--rw tsg?          identityref
+       +--rw priority?     uint8
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:label-restriction/tet:label-start/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:label-restriction/tet:label-end/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:underlay/tet:backup-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:optimizations/tet:algorithm/tet:metric/tet:optimization-metric/tet:explicit-route-exclude-objects/tet:route-object-exclude-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:optimizations/tet:algorithm/tet:metric/tet:optimization-metric/tet:explicit-route-include-objects/tet:route-object-include-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:path-properties/tet:path-route-objects/tet:path-route-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:from/tet:label-restriction:
+    +--rw otn-label-restriction
+       +--rw range-type?   identityref
+       +--rw tsg?          identityref
+       +--rw priority?     uint8
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:from/tet:label-restriction/tet:label-start/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:from/tet:label-restriction/tet:label-end/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:to/tet:label-restriction:
+    +--rw otn-label-restriction
+       +--rw range-type?   identityref
+       +--rw tsg?          identityref
+       +--rw priority?     uint8
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:to/tet:label-restriction/tet:label-start/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:to/tet:label-restriction/tet:label-end/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:underlay/tet:backup-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:optimizations/tet:algorithm/tet:metric/tet:optimization-metric/tet:explicit-route-exclude-objects/tet:route-object-exclude-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:optimizations/tet:algorithm/tet:metric/tet:optimization-metric/tet:explicit-route-include-objects/tet:route-object-include-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:path-properties/tet:path-route-objects/tet:path-route-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:label-restriction:
+    +--ro otn-label-restriction
+       +--ro range-type?   identityref
+       +--ro tsg?          identityref
+       +--ro priority?     uint8
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:label-restriction/tet:label-start/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro (otn-label-type)?
+             +--:(tributary-port)
+             |  +--ro tpn?   uint16
+             +--:(tributary-slot)
+                +--ro ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:label-restriction/tet:label-end/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro (otn-label-type)?
+             +--:(tributary-port)
+             |  +--ro tpn?   uint16
+             +--:(tributary-slot)
+                +--ro ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:underlay/tet:backup-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:optimizations/tet:algorithm/tet:metric/tet:optimization-metric/tet:explicit-route-exclude-objects/tet:route-object-exclude-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:optimizations/tet:algorithm/tet:metric/tet:optimization-metric/tet:explicit-route-include-objects/tet:route-object-include-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:path-properties/tet:path-route-objects/tet:path-route-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:from/tet:label-restriction:
+    +--ro otn-label-restriction
+       +--ro range-type?   identityref
+       +--ro tsg?          identityref
+       +--ro priority?     uint8
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:from/tet:label-restriction/tet:label-start/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro (otn-label-type)?
+             +--:(tributary-port)
+             |  +--ro tpn?   uint16
+             +--:(tributary-slot)
+                +--ro ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:from/tet:label-restriction/tet:label-end/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro (otn-label-type)?
+             +--:(tributary-port)
+             |  +--ro tpn?   uint16
+             +--:(tributary-slot)
+                +--ro ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:to/tet:label-restriction:
+    +--ro otn-label-restriction
+       +--ro range-type?   identityref
+       +--ro tsg?          identityref
+       +--ro priority?     uint8
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:to/tet:label-restriction/tet:label-start/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro (otn-label-type)?
+             +--:(tributary-port)
+             |  +--ro tpn?   uint16
+             +--:(tributary-slot)
+                +--ro ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:to/tet:label-restriction/tet:label-end/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro (otn-label-type)?
+             +--:(tributary-port)
+             |  +--ro tpn?   uint16
+             +--:(tributary-slot)
+                +--ro ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:underlay/tet:backup-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:optimizations/tet:algorithm/tet:metric/tet:optimization-metric/tet:explicit-route-exclude-objects/tet:route-object-exclude-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:optimizations/tet:algorithm/tet:metric/tet:optimization-metric/tet:explicit-route-include-objects/tet:route-object-include-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:path-properties/tet:path-route-objects/tet:path-route-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:label-restriction:
+    +--rw otn-label-restriction
+       +--rw range-type?   identityref
+       +--rw tsg?          identityref
+       +--rw priority?     uint8
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:label-restriction/tet:label-start/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:label-restriction/tet:label-end/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:underlay/tet:backup-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:optimizations/tet:algorithm/tet:metric/tet:optimization-metric/tet:explicit-route-exclude-objects/tet:route-object-exclude-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:optimizations/tet:algorithm/tet:metric/tet:optimization-metric/tet:explicit-route-include-objects/tet:route-object-include-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:path-properties/tet:path-route-objects/tet:path-route-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity/tet:label-restriction:
+    +--rw otn-label-restriction
+       +--rw range-type?   identityref
+       +--rw tsg?          identityref
+       +--rw priority?     uint8
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity/tet:label-restriction/tet:label-start/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity/tet:label-restriction/tet:label-end/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity/tet:underlay/tet:backup-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity/tet:optimizations/tet:algorithm/tet:metric/tet:optimization-metric/tet:explicit-route-exclude-objects/tet:route-object-exclude-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity/tet:optimizations/tet:algorithm/tet:metric/tet:optimization-metric/tet:explicit-route-include-objects/tet:route-object-include-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity/tet:path-properties/tet:path-route-objects/tet:path-route-object/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro tpn?       uint16
+          +--ro tsg?       identityref
+          +--ro ts-list?   string
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes/tet:underlay/tet:backup-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes/tet:label-restriction:
+    +--rw otn-label-restriction
+       +--rw range-type?   identityref
+       +--rw tsg?          identityref
+       +--rw priority?     uint8
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes/tet:label-restriction/tet:label-start/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes/tet:label-restriction/tet:label-end/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:information-source-entry/tet:label-restriction:
+    +--ro otn-label-restriction
+       +--ro range-type?   identityref
+       +--ro tsg?          identityref
+       +--ro priority?     uint8
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:information-source-entry/tet:label-restriction/tet:label-start/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro (otn-label-type)?
+             +--:(tributary-port)
+             |  +--ro tpn?   uint16
+             +--:(tributary-slot)
+                +--ro ts?    uint16
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:information-source-entry/tet:label-restriction/tet:label-end/tet:te-label/tet:technology:
+    +--:(otn)
+       +--ro otn
+          +--ro (otn-label-type)?
+             +--:(tributary-port)
+             |  +--ro tpn?   uint16
+             +--:(tributary-slot)
+                +--ro ts?    uint16
+  augment /nw:networks/tet:te/tet:templates/tet:link-template/tet:te-link-attributes/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/tet:te/tet:templates/tet:link-template/tet:te-link-attributes/tet:underlay/tet:backup-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw tpn?       uint16
+          +--rw tsg?       identityref
+          +--rw ts-list?   string
+  augment /nw:networks/tet:te/tet:templates/tet:link-template/tet:te-link-attributes/tet:label-restriction:
+    +--rw otn-label-restriction
+       +--rw range-type?   identityref
+       +--rw tsg?          identityref
+       +--rw priority?     uint8
+  augment /nw:networks/tet:te/tet:templates/tet:link-template/tet:te-link-attributes/tet:label-restriction/tet:label-start/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16
+  augment /nw:networks/tet:te/tet:templates/tet:link-template/tet:te-link-attributes/tet:label-restriction/tet:label-end/tet:te-label/tet:technology:
+    +--:(otn)
+       +--rw otn
+          +--rw (otn-label-type)?
+             +--:(tributary-port)
+             |  +--rw tpn?   uint16
+             +--:(tributary-slot)
+                +--rw ts?    uint16

--- a/YANG/ccamp/otn-topology/ietf-otn-topology.yang
+++ b/YANG/ccamp/otn-topology/ietf-otn-topology.yang
@@ -1,0 +1,189 @@
+module ietf-otn-topology {
+  yang-version 1.1;
+
+  namespace "urn:ietf:params:xml:ns:yang:ietf-otn-topology";
+  prefix "otntopo";
+
+  import ietf-network {
+    prefix "nw";
+  }
+
+  import ietf-network-topology {
+    prefix "nt";
+  }
+
+  import ietf-te-topology {
+    prefix "tet";
+  }
+
+  import ietf-otn-types {
+    prefix "otn-types"; 
+  }
+
+  organization 
+    "IETF CCAMP Working Group";
+  contact
+    "WG Web: <http://tools.ietf.org/wg/ccamp/>
+     WG List: <mailto:ccamp@ietf.org>
+
+     Editor: Haomian Zheng
+             <mailto:zhenghaomian@huawei.com>
+
+     Editor: Zheyu Fan
+             <mailto:fanzheyu2@huawei.com>
+
+     Editor: Anurag Sharma
+             <mailto:ansha@google.com>
+
+     Editor: Xufeng Liu
+             <mailto:Xufeng_Liu@jabil.com>
+
+     Editor: Sergio Belotti
+             <mailto:sergio.belotti@nokia.com>
+
+     Editor: Yunbin Xu
+             <mailto:xuyunbin@ritt.cn>
+
+     Editor: Lei Wang
+             <mailto:wangleiyj@chinamobile.com>
+
+     Editor: Oscar Gonzalez de Dios
+             <mailto:oscar.gonzalezdedios@telefonica.com>";
+
+  description
+    "This module defines a protocol independent Layer 1/ODU topology
+     data model.";
+
+  revision 2017-10-30 {
+    description
+      "Revision 0.5";
+    reference
+      "draft-ietf-ccamp-otn-topo-yang-02.txt";
+  }
+
+ /*
+  * Groupings
+  */
+  grouping otn-link-attributes {
+    description "link attributes for OTN";
+
+    list available-odu-info {
+      key "priority";
+      max-elements "8";
+      description "List of ODU type and number on this link";
+      leaf priority {
+        type uint8 {
+          range "0..7";
+        }
+        description "priority";
+      }
+      list odulist {
+        key "odu-type";
+        description 
+          "the list of available ODUs per priority level";
+        leaf odu-type {
+          type identityref {
+            base otn-types:tributary-protocol-type;
+          }
+          description "the type of ODU";
+        }
+        leaf number {
+          type uint16;
+          description "the number of odu type supported";
+        }
+        leaf tpn-range {
+          type string {
+            pattern "([1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?"
+                  + "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
+          }
+          description
+            "A list of available tributary port number range
+             between 1 and 9999.
+             For example 1-20,25,50-1000";
+          reference "RFC 7139: GMPLS Signaling Extensions for Control
+                     of Evolving G.709 Optical Transport Networks";
+        }
+      }
+      leaf ts-range {
+        type string {
+          pattern "([1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?"
+                + "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
+        }
+        description
+          "A list of available tributary slot range
+           between 1 and 9999.
+           For example 1-20,25,50-1000";
+        reference "RFC 7139: GMPLS Signaling Extensions for Control
+                   of Evolving G.709 Optical Transport Networks";
+      }
+    }
+    leaf tsg {
+      type identityref {
+        base otn-types:tributary-slot-granularity;
+      }
+      description "Tributary slot granularity.";
+      reference
+        "G.709/Y.1331, February 2016: Interfaces for the 
+         Optical Transport Network (OTN)";
+    }
+    leaf distance {
+      type uint32; 
+      description "distance in the unit of kilometers";
+    }
+  }
+
+  grouping otn-tp-attributes {
+    description "tp attributes for OTN";
+    list supported-payload-types {
+      key "index";
+      description
+        "Supported payload types of a TP. The payload type is defined
+         as the generalized PIDs in GMPLS.";
+      leaf index {
+        type uint16; 
+        description "payload type index";
+      }
+      leaf payload-type {
+        type string; 
+        description "the payload type supported by this client tp";
+        reference
+          "http://www.iana.org/assignments/gmpls-sig-parameters
+           /gmpls-sig-parameters.xhtml";
+      }
+    }
+  }
+
+ /*
+  * Data nodes
+  */
+  augment "/nw:networks/nw:network/nw:network-types/"
+        + "tet:te-topology" {
+    container otn-topology {
+      presence "indicates a topology type of Optical Transport 
+                Network (OTN)-electrical layer.";
+      description "otn topology type";
+    }
+    description "augment network types to include otn newtork";
+  }
+
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:te-link-attributes" {
+    when "../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment only for otn network.";
+    }
+    description "Augment link configuration";
+    uses otn-link-attributes;
+  }
+
+  augment "/nw:networks/nw:network/nw:node/nt:termination-point/"
+        + "tet:te" {
+    when "../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment only for otn network";
+    }
+    description "OTN TP attributes config in ODU topology.";
+    uses otn-tp-attributes;
+  }
+}
+

--- a/YANG/ccamp/otn-topology/ietf-otn-topology.yang
+++ b/YANG/ccamp/otn-topology/ietf-otn-topology.yang
@@ -17,10 +17,10 @@ module ietf-otn-topology {
   }
 
   import ietf-otn-types {
-    prefix "otn-types"; 
+    prefix "otn-types";
   }
 
-  organization 
+  organization
     "IETF CCAMP Working Group";
   contact
     "WG Web: <http://tools.ietf.org/wg/ccamp/>
@@ -29,8 +29,11 @@ module ietf-otn-topology {
      Editor: Haomian Zheng
              <mailto:zhenghaomian@huawei.com>
 
-     Editor: Zheyu Fan
-             <mailto:fanzheyu2@huawei.com>
+     Editor: Aihua Guo
+             <mailto:aihuaguo@huawei.com>
+
+     Editor: Italo Busi
+             <mailto:italo.busi@huawei.com>
 
      Editor: Anurag Sharma
              <mailto:ansha@google.com>
@@ -54,80 +57,31 @@ module ietf-otn-topology {
     "This module defines a protocol independent Layer 1/ODU topology
      data model.";
 
-  revision 2017-10-30 {
+  revision 2018-05-23 {
     description
-      "Revision 0.5";
+      "Revision 0.6";
     reference
-      "draft-ietf-ccamp-otn-topo-yang-02.txt";
+      "draft-ietf-ccamp-otn-topo-yang-03";
   }
 
  /*
   * Groupings
   */
+
   grouping otn-link-attributes {
     description "link attributes for OTN";
 
-    list available-odu-info {
-      key "priority";
-      max-elements "8";
-      description "List of ODU type and number on this link";
-      leaf priority {
-        type uint8 {
-          range "0..7";
-        }
-        description "priority";
-      }
-      list odulist {
-        key "odu-type";
-        description 
-          "the list of available ODUs per priority level";
-        leaf odu-type {
-          type identityref {
-            base otn-types:tributary-protocol-type;
-          }
-          description "the type of ODU";
-        }
-        leaf number {
-          type uint16;
-          description "the number of odu type supported";
-        }
-        leaf tpn-range {
-          type string {
-            pattern "([1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?"
-                  + "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
-          }
-          description
-            "A list of available tributary port number range
-             between 1 and 9999.
-             For example 1-20,25,50-1000";
-          reference "RFC 7139: GMPLS Signaling Extensions for Control
-                     of Evolving G.709 Optical Transport Networks";
-        }
-      }
-      leaf ts-range {
-        type string {
-          pattern "([1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?"
-                + "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
-        }
-        description
-          "A list of available tributary slot range
-           between 1 and 9999.
-           For example 1-20,25,50-1000";
-        reference "RFC 7139: GMPLS Signaling Extensions for Control
-                   of Evolving G.709 Optical Transport Networks";
-      }
-    }
     leaf tsg {
       type identityref {
         base otn-types:tributary-slot-granularity;
       }
       description "Tributary slot granularity.";
       reference
-        "G.709/Y.1331, February 2016: Interfaces for the 
+        "G.709/Y.1331, February 2016: Interfaces for the
          Optical Transport Network (OTN)";
     }
     leaf distance {
-      type uint32; 
+      type uint32;
       description "distance in the unit of kilometers";
     }
   }
@@ -140,11 +94,11 @@ module ietf-otn-topology {
         "Supported payload types of a TP. The payload type is defined
          as the generalized PIDs in GMPLS.";
       leaf index {
-        type uint16; 
+        type uint16;
         description "payload type index";
       }
       leaf payload-type {
-        type string; 
+        type string;
         description "the payload type supported by this client tp";
         reference
           "http://www.iana.org/assignments/gmpls-sig-parameters
@@ -156,10 +110,11 @@ module ietf-otn-topology {
  /*
   * Data nodes
   */
+
   augment "/nw:networks/nw:network/nw:network-types/"
         + "tet:te-topology" {
     container otn-topology {
-      presence "indicates a topology type of Optical Transport 
+      presence "indicates a topology type of Optical Transport
                 Network (OTN)-electrical layer.";
       description "otn topology type";
     }
@@ -185,5 +140,1439 @@ module ietf-otn-topology {
     description "OTN TP attributes config in ODU topology.";
     uses otn-tp-attributes;
   }
-}
 
+  /*
+   * Augment TE bandwidth
+   */
+  
+  /* Augment maximum LSP bandwidth of link terminationpoint (LTP) */
+  augment "/nw:networks/nw:network/nw:node/nt:termination-point/"
+        + "tet:te/"
+        + "tet:interface-switching-capability/tet:max-lsp-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE bandwidth";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-path-bandwidth;
+    }
+  }
+
+  /* Augment bandwidth path constraints of connectivity-matrices */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:path-constraints/tet:te-bandwidth/tet:technology" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE bandwidth";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+
+  /* Augment bandwidth path constraints of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:path-constraints/tet:te-bandwidth/tet:technology" {
+    when "../../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE bandwidth";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+
+  /* Augment bandwidth path constraints of connectivity-matrices information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:path-constraints/tet:te-bandwidth/tet:technology" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE bandwidth";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+
+  /* Augment bandwidth path constraints of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:path-constraints/tet:te-bandwidth/tet:technology" {
+    when "../../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE bandwidth";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+  
+  /* Augment client bandwidth of tunnel termination point (TTP) */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:client-layer-adaptation/tet:switching-capability/"
+        + "tet:te-bandwidth/tet:technology" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE bandwidth";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+  
+  /* Augment bandwidth path constraints of local-link-connectivities */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/tet:path-constraints/"
+        + "tet:te-bandwidth/tet:technology" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE bandwidth";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  } 
+
+  /* Augment bandwidth path constraints of local-link-connectivity (LLC) */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:local-link-connectivity/tet:path-constraints/"
+        + "tet:te-bandwidth/tet:technology" {
+    when "../../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE bandwidth";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+  
+  /* Augment maximum LSP bandwidth of TE link */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:te-link-attributes/"
+        + "tet:interface-switching-capability/tet:max-lsp-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "OTN TE bandwidth.";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-path-bandwidth;
+    }
+  }
+
+  /* Augment maximum bandwidth of TE link */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:te-link-attributes/"
+        + "tet:max-link-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+    when "../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "OTN TE bandwidth.";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+
+  /* Augment maximum reservable bandwidth of TE link */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:te-link-attributes/"
+        + "tet:max-resv-link-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+    when "../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "OTN TE bandwidth.";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+
+  /* Augment unreserved bandwidth of TE Link */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:te-link-attributes/"
+        + "tet:unreserved-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+    when "../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "OTN TE bandwidth.";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+  
+  /* Augment maximum LSP bandwidth of TE link information-source */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:information-source-entry/"
+        + "tet:interface-switching-capability/"
+        + "tet:max-lsp-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "OTN TE bandwidth.";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-path-bandwidth;
+    }
+  }
+
+  /* Augment maximum bandwidth of TE link information-source */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:information-source-entry/"
+        + "tet:max-link-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+    when "../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "OTN TE bandwidth.";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+
+  /* Augment maximum reservable bandwidth of TE link information-source */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:information-source-entry/"
+        + "tet:max-resv-link-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+    when "../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "OTN TE bandwidth.";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+
+  /* Augment unreserved bandwidth of TE link information-source */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:information-source-entry/"
+        + "tet:unreserved-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+    when "../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "OTN TE bandwidth.";
+    }
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+  
+  /* Augment maximum LSP bandwidth of TE link template */
+  augment "/nw:networks/tet:te/tet:templates/"
+        + "tet:link-template/tet:te-link-attributes/"
+        + "tet:interface-switching-capability/"
+        + "tet:max-lsp-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+/*
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "OTN TE bandwidth.";
+    }
+*/
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-path-bandwidth;
+    }
+  }
+  
+  /* Augment maximum bandwidth of TE link template */
+  augment "/nw:networks/tet:te/tet:templates/"
+        + "tet:link-template/tet:te-link-attributes/"
+        + "tet:max-link-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+/*
+    when "../../../../../../nw:network-types/tet:te-topology/"
+        + "otntopo:otn-topology" {
+      description "OTN TE bandwidth.";
+    }
+*/
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+  
+  /* Augment maximum reservable bandwidth of TE link template */
+  augment "/nw:networks/tet:te/tet:templates/"
+        + "tet:link-template/tet:te-link-attributes/"
+        + "tet:max-resv-link-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+/*
+    when "../../../../../../nw:network-types/tet:te-topology/"
+        + "otntopo:otn-topology" {
+      description "OTN TE bandwidth.";
+    }
+*/
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+
+  /* Augment unreserved bandwidth of TE link template */
+  augment "/nw:networks/tet:te/tet:templates/"
+        + "tet:link-template/tet:te-link-attributes/"
+        + "tet:unreserved-bandwidth/"
+        + "tet:te-bandwidth/tet:technology" {
+/*
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+        + "otntopo:otn-topology" {
+      description "OTN TE bandwidth.";
+    }
+*/
+    description "OTN bandwidth.";
+    case otn {
+      uses otn-types:otn-link-bandwidth;
+    }
+  }
+
+  /*
+   * Augment TE label.
+   */
+
+  /* Augment label restrictions of connectivity-matrices */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:label-restriction" {
+    when "../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    uses otn-types:otn-label-restriction;
+  }
+
+  /* Augment label restrictions start of connectivity-matrices */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:label-restriction/tet:label-start/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label restrictions end of connectivity-matrices */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:label-restriction/tet:label-end/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label hop of underlay primary path of connectivity-matrices */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:underlay/tet:primary-path/tet:path-element/"
+        + "tet:type/tet:label/tet:label-hop/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of underlay backup path of connectivity-matrices */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:underlay/tet:backup-path/tet:path-element/"
+        + "tet:type/tet:label/tet:label-hop/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of route-exclude of connectivity-matrices */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:optimizations/tet:algorithm/tet:metric/"
+        + "tet:optimization-metric/"
+        + "tet:explicit-route-exclude-objects/"
+        + "tet:route-object-exclude-object/"
+        + "tet:type/tet:label/tet:label-hop/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of route-include of connectivity-matrices (added) */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:optimizations/tet:algorithm/tet:metric/"
+        + "tet:optimization-metric/"
+        + "tet:explicit-route-include-objects/"
+        + "tet:route-object-include-object/"
+        + "tet:type/tet:label/tet:label-hop/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of path-route of connectivity-matrices */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:path-properties/tet:path-route-objects/"
+        + "tet:path-route-object/tet:type/tet:label/tet:label-hop/"
+        + "tet:te-label/tet:technology"{
+    when "../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment ingress label restrictions of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/tet:from/"
+        + "tet:label-restriction" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    uses otn-types:otn-label-restriction;
+  }
+
+  /* Augment ingress label restrictions start of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/tet:from/"
+        + "tet:label-restriction/tet:label-start/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment ingress label restrictions end of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/tet:from/"
+        + "tet:label-restriction/tet:label-end/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment egress label restrictions of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/tet:to/"
+        + "tet:label-restriction" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    uses otn-types:otn-label-restriction;
+  }
+
+  /* Augment egress label restrictions start of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/tet:to/"
+        + "tet:label-restriction/tet:label-start/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment egress label restrictions end of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/tet:to/"
+        + "tet:label-restriction/tet:label-end/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label hop of underlay primary path of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:underlay/tet:primary-path/tet:path-element/"
+        + "tet:type/tet:label/tet:label-hop/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of underlay backup path of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:underlay/tet:backup-path/tet:path-element/"
+        + "tet:type/tet:label/tet:label-hop/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of route-exclude of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/tet:optimizations/"
+        + "tet:algorithm/tet:metric/tet:optimization-metric/"
+        + "tet:explicit-route-exclude-objects/"
+        + "tet:route-object-exclude-object/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of route-include of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/tet:optimizations/"
+        + "tet:algorithm/tet:metric/tet:optimization-metric/"
+        + "tet:explicit-route-include-objects/"
+        + "tet:route-object-include-object/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of path-route of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:path-properties/tet:path-route-objects/"		
+        + "tet:path-route-object/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label restrictions of connectivity-matrices information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/"
+        + "tet:connectivity-matrices/tet:label-restriction" {
+    when "../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    uses otn-types:otn-label-restriction;
+  }
+
+  /* Augment label restrictions start of connectivity-matrices information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/"
+        + "tet:connectivity-matrices/tet:label-restriction/"
+        + "tet:label-start/tet:te-label/tet:technology" {
+    when "../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label restrictions end of connectivity-matrices information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/"
+        + "tet:connectivity-matrices/tet:label-restriction/"
+        + "tet:label-end/tet:te-label/tet:technology" {
+    when "../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label hop of underlay primary path of connectivity-matrices information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:underlay/tet:primary-path/tet:path-element/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of underlay backup path of connectivity-matrices information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:underlay/tet:backup-path/tet:path-element/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of route-exclude of connectivity-matrices information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:optimizations/tet:algorithm/tet:metric/"
+        + "tet:optimization-metric/"
+        + "tet:explicit-route-exclude-objects/"
+        + "tet:route-object-exclude-object/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of route-include of connectivity-matrices information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:optimizations/tet:algorithm/tet:metric/"
+        + "tet:optimization-metric/"
+        + "tet:explicit-route-include-objects/"
+        + "tet:route-object-include-object/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of path-route of connectivity-matrices information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:path-properties/tet:path-route-objects/"
+        + "tet:path-route-object/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment ingress label restrictions of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:from/tet:label-restriction" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    uses otn-types:otn-label-restriction;
+  }
+
+  /* Augment ingress label restrictions start of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:from/tet:label-restriction/"
+        + "tet:label-start/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment ingress label restrictions end of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:from/tet:label-restriction/"
+        + "tet:label-end/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment egress label restrictions of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:to/tet:label-restriction" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    uses otn-types:otn-label-restriction;
+  }
+
+  /* Augment egress label restrictions start of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:to/tet:label-restriction/"
+        + "tet:label-start/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment egress label restrictions end of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:to/tet:label-restriction/"
+        + "tet:label-end/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label hop of underlay primary path of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:underlay/tet:primary-path/tet:path-element/tet:type/" 
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of underlay backup path of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:underlay/tet:backup-path/tet:path-element/tet:type/" 
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of route-exclude of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:optimizations/tet:algorithm/tet:metric/"
+        + "tet:optimization-metric/"
+        + "tet:explicit-route-exclude-objects/"
+        + "tet:route-object-exclude-object/tet:type/"		
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of route-include of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:optimizations/tet:algorithm/tet:metric/"
+        + "tet:optimization-metric/"
+        + "tet:explicit-route-include-objects/"
+        + "tet:route-object-include-object/tet:type/"		
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of path-route of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:path-properties/tet:path-route-objects/"
+        + "tet:path-route-object/tet:type/"	
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label restrictions of local-link-connectivities */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:label-restriction" {
+    when "../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    uses otn-types:otn-label-restriction;
+  }
+
+  /* Augment label restrictions start of local-link-connectivities */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:label-restriction/tet:label-start/"
+        + "tet:te-label/tet:technology" {
+    when "../../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label restrictions end of local-link-connectivities */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:label-restriction/tet:label-end/"
+        + "tet:te-label/tet:technology"{
+    when "../../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label hop of underlay primary path of local-link-connectivities */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:underlay/tet:primary-path/tet:path-element/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of underlay backup path of local-link-connectivities */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:underlay/tet:backup-path/tet:path-element/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of route-exclude of local-link-connectivities */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:optimizations/tet:algorithm/tet:metric/"
+        + "tet:optimization-metric/"
+        + "tet:explicit-route-exclude-objects/"
+        + "tet:route-object-exclude-object/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of route-include of local-link-connectivities */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:optimizations/tet:algorithm/tet:metric/"
+        + "tet:optimization-metric/"
+        + "tet:explicit-route-include-objects/"
+        + "tet:route-object-include-object/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of path-route of local-link-connectivities */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:path-properties/tet:path-route-objects/"
+        + "tet:path-route-object/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label restrictions of local-link-connectivity (LLC) */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:local-link-connectivity/"
+        + "tet:label-restriction" {
+    when "../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    uses otn-types:otn-label-restriction;
+  }
+
+  /* Augment label restrictions start of local-link-connectivity (LLC) */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:local-link-connectivity/"
+        + "tet:label-restriction/"
+        + "tet:label-start/tet:te-label/tet:technology" {
+    when "../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label restrictions end of local-link-connectivity (LLC) */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:local-link-connectivity/"
+        + "tet:label-restriction/"
+        + "tet:label-end/tet:te-label/tet:technology" {
+    when "../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label hop of underlay primary path of local-link-connectivity (LLC) */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:local-link-connectivity/"
+        + "tet:underlay/tet:primary-path/tet:path-element/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of underlay backup path of local-link-connectivity (LLC) */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:local-link-connectivity/"
+        + "tet:underlay/tet:backup-path/tet:path-element/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of route-exclude of local-link-connectivity (LLC) */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:local-link-connectivity/"
+        + "tet:optimizations/tet:algorithm/tet:metric/"
+        + "tet:optimization-metric/"
+        + "tet:explicit-route-exclude-objects/"
+        + "tet:route-object-exclude-object/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of route-include of local-link-connectivity (LLC) */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:local-link-connectivity/"
+        + "tet:optimizations/tet:algorithm/tet:metric/"
+        + "tet:optimization-metric/"
+        + "tet:explicit-route-include-objects/"
+        + "tet:route-object-include-object/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of path-route of local-link-connectivity (LLC) */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:local-link-connectivity/"
+        + "tet:path-properties/tet:path-route-objects/"
+        + "tet:path-route-object/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of underlay primary path of TE link */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:te-link-attributes/"
+        + "tet:underlay/tet:primary-path/tet:path-element/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of underlay backup path of TE link */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:te-link-attributes/"
+        + "tet:underlay/tet:backup-path/tet:path-element/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+    when "../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label restrictions of TE link */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:te-link-attributes/"
+        + "tet:label-restriction" {
+    when "../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    uses otn-types:otn-label-restriction;
+  }
+
+  /* Augment label restrictions start of TE link */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:te-link-attributes/"
+        + "tet:label-restriction/"
+        + "tet:label-start/tet:te-label/tet:technology" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label restrictions end of TE link */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:te-link-attributes/"
+        + "tet:label-restriction/"
+        + "tet:label-end/tet:te-label/tet:technology" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label restrictions of TE link information-source */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:information-source-entry/"
+        + "tet:label-restriction" {
+    when "../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    uses otn-types:otn-label-restriction;
+  }
+
+  /* Augment label restrictions start of TE link information-source */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:information-source-entry/"
+        + "tet:label-restriction/"
+        + "tet:label-start/tet:te-label/tet:technology" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label restrictions end of TE link information-source */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:information-source-entry/"
+        + "tet:label-restriction/"
+        + "tet:label-end/tet:te-label/tet:technology" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label hop of underlay primary path of TE link template */
+  augment "/nw:networks/tet:te/tet:templates/"
+        + "tet:link-template/tet:te-link-attributes/"
+        + "tet:underlay/tet:primary-path/tet:path-element/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+/*
+    when "../../../../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+			 description "Augment OTN TE label";
+    }
+*/
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label hop of underlay backup path of TE link template */
+  augment "/nw:networks/tet:te/tet:templates/"
+        + "tet:link-template/tet:te-link-attributes/" 
+        + "tet:underlay/tet:backup-path/tet:path-element/tet:type/"
+        + "tet:label/tet:label-hop/tet:te-label/tet:technology" {
+/*
+    when "../../../../../../../../../../../../nw:network-types/tet:te-topology/"
+        + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+*/
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-path-label;
+    }
+  }
+
+  /* Augment label restrictions of TE link template */
+  augment "/nw:networks/tet:te/tet:templates/"
+        + "tet:link-template/tet:te-link-attributes/"
+        + "tet:label-restriction" {
+/*
+    when "../../../../../nw:network-types/tet:te-topology/"
+        + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+*/
+    description "OTN label.";
+    uses otn-types:otn-label-restriction;
+  }
+
+  /* Augment label restrictions start of TE link template */
+  augment "/nw:networks/tet:te/tet:templates/"
+        + "tet:link-template/tet:te-link-attributes/"
+        + "tet:label-restriction/"
+        + "tet:label-start/tet:te-label/tet:technology" {
+/*
+    when "../../../../../../../../nw:network-types/tet:te-topology/"
+        + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+*/
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label restrictions end of TE link template */
+  augment "/nw:networks/tet:te/tet:templates/"
+        + "tet:link-template/tet:te-link-attributes/"
+        + "tet:label-restriction/" 
+        + "tet:label-end/tet:te-label/tet:technology" {
+/*
+    when "../../../../../../../../nw:network-types/tet:te-topology/"
+        + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+*/
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-link-label;
+    }
+  }
+}

--- a/YANG/ccamp/otn-tunnel/ietf-otn-types.yang
+++ b/YANG/ccamp/otn-tunnel/ietf-otn-types.yang
@@ -11,8 +11,11 @@ module ietf-otn-types {
      Editor: Haomian Zheng
              <mailto:zhenghaomian@huawei.com>
 
-     Editor: Zheyu Fan
-             <mailto:fanzheyu2@huawei.com>
+     Editor: Aihua Guo
+             <mailto:aihuaguo@huawei.com>
+
+     Editor: Italo Busi
+             <mailto:italo.busi@huawei.com>
 
      Editor: Anurag Sharma
              <mailto:ansha@google.com>
@@ -35,11 +38,11 @@ module ietf-otn-types {
   description
     "This module defines OTN types.";
 
-  revision "2017-10-30" {
+  revision "2018-05-23" {
     description
-      "Revision 0.4";
+      "Revision 0.5";
     reference
-      "draft-ietf-ccamp-otn-tunnel-model-01.txt";
+      "draft-ietf-ccamp-otn-tunnel-model-02";
   }
 
   identity tributary-slot-granularity {
@@ -230,7 +233,6 @@ module ietf-otn-types {
     description
       "1G Ethernet protocol";
   }
-
   identity prot-10GbE-LAN {
     base tributary-protocol-type;
     description
@@ -397,5 +399,176 @@ module ietf-otn-types {
     base client-signal;
     description
       "Client signal type of Fibre Connection 8G";
+  }
+
+  identity client-signal-OTU1 {
+    base client-signal;
+    description
+      "Client signal type of OTU1";
+  }
+
+  identity client-signal-OTU2 {
+    base client-signal;
+    description
+      "Client signal type of OTU2";
+  }
+
+  identity client-signal-OTU2e {
+    base client-signal;
+    description
+      "Client signal type of OTU2e";
+  }
+
+  identity client-signal-OTU3 {
+    base client-signal;
+    description
+      "Client signal type of OTU3";
+  }
+
+  identity client-signal-OTU4 {
+    base client-signal;
+    description
+      "Client signal type of OTU4";
+  }
+
+  identity otn-label-range-type {
+    description
+      "Base identity from which specific OTN label
+	   range types derived";
+  }
+
+  identity label-range-trib-slot {
+    base otn-label-range-type;
+    description
+      "Defines a range of OTN tributary slots";
+  }
+
+  identity label-range-trib-port {
+    base otn-label-range-type;
+    description
+      "Defines a range of OTN tributary ports";
+  }
+  
+  grouping otn-link-bandwidth {
+    container otn {
+      list odulist {
+        key "odu-type";
+        description
+          "OTN bandwidth definition";
+        leaf odu-type {
+          type identityref {
+            base otn-types:tributary-protocol-type;
+          }
+          description "ODU type";
+        }
+        leaf number {
+          type uint16;
+          description "Number of ODUs";
+        }
+      }
+    }
+  }
+
+  grouping otn-path-bandwidth {
+    container otn {
+      leaf odu-type {
+        type identityref {
+          base otn-types:tributary-protocol-type;
+        }
+        description "ODU type";
+      }
+    }
+  }
+
+  grouping otn-label-restriction {
+    container otn-label-restriction {
+      leaf range-type {
+	      type identityref {
+	        base otn-types:otn-label-range-type;
+	      }
+	    }
+      leaf tsg {
+        type identityref {
+          base otn-types:tributary-slot-granularity;
+        }
+        description "Tributary slot granularity.";
+        reference
+          "G.709/Y.1331, February 2016: Interfaces for the
+           Optical Transport Network (OTN)";
+      } 
+      leaf priority {
+	      type uint8;
+	      description "priority.";
+	    }
+    }
+  }
+ 
+  grouping otn-link-label {
+	  container otn {
+      choice otn-label-type {
+        description
+          "OTN label type";
+        case tributary-port {
+          leaf tpn {
+            type uint16 {
+              range "1..4095";
+            }
+            description
+              "Tributary Port Number. Applicable in case of mux services.";
+            reference
+              "RFC7139: GMPLS Signaling Extensions for Control of Evolving
+               G.709 Optical Transport Networks.";
+          }
+        }
+        case tributary-slot {
+          leaf ts {
+            type uint16 {
+              range "1..4095";
+            }
+            description
+              "Tributary Slot Number. Applicable in case of mux services.";
+            reference
+              "RFC7139: GMPLS Signaling Extensions for Control of Evolving
+               G.709 Optical Transport Networks.";
+          }
+        }
+      }
+    }
+  }
+
+  grouping otn-path-label {
+    container otn {
+      leaf tpn {
+        type uint16 {
+          range "1..4095";
+        }
+        description
+          "Tributary Port Number. Applicable in case of mux services.";
+        reference
+          "RFC7139: GMPLS Signaling Extensions for Control of Evolving
+           G.709 Optical Transport Networks.";
+      }
+      leaf tsg {
+        type identityref {
+          base otn-types:tributary-slot-granularity;
+        }
+        description "Tributary slot granularity.";
+        reference
+          "G.709/Y.1331, February 2016: Interfaces for the
+           Optical Transport Network (OTN)";
+      }
+      leaf ts-list {
+        type string {
+            pattern "([1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?"
+                  + "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
+          }
+          description
+            "A list of available tributary slots ranging
+             between 1 and 9999.
+             For example 1-20,25,50-1000";
+          reference "RFC 7139: GMPLS Signaling Extensions for Control
+                     of Evolving G.709 Optical Transport Networks";
+      }
+    }
   }
 }

--- a/YANG/ccamp/otn-tunnel/ietf-otn-types.yang
+++ b/YANG/ccamp/otn-tunnel/ietf-otn-types.yang
@@ -1,0 +1,401 @@
+module ietf-otn-types {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-otn-types";
+  prefix "otn-types";
+
+  organization
+    "IETF CCAMP Working Group";
+  contact
+    "WG Web: <http://tools.ietf.org/wg/ccamp/>
+     WG List: <mailto:ccamp@ietf.org>
+
+     Editor: Haomian Zheng
+             <mailto:zhenghaomian@huawei.com>
+
+     Editor: Zheyu Fan
+             <mailto:fanzheyu2@huawei.com>
+
+     Editor: Anurag Sharma
+             <mailto:ansha@google.com>
+
+     Editor: Rajan Rao
+             <mailto:rrao@infinera.com>
+
+     Editor: Sergio Belotti
+             <mailto:sergio.belotti@nokia.com>
+
+     Editor: Victor Lopez
+             <mailto:victor.lopezalvarez@telefonica.com>
+
+     Editor: Yunbo Li
+             <mailto:liyunbo@chinamobile.com>
+
+     Editor: Yunbin Xu
+             <mailto:xuyunbin@ritt.cn>";
+
+  description
+    "This module defines OTN types.";
+
+  revision "2017-10-30" {
+    description
+      "Revision 0.4";
+    reference
+      "draft-ietf-ccamp-otn-tunnel-model-01.txt";
+  }
+
+  identity tributary-slot-granularity {
+    description
+      "Tributary slot granularity";
+    reference
+      "G.709/Y.1331, February 2016: Interfaces for the Optical
+       Transport Network (OTN)";
+  }
+
+  identity tsg-1.25G {
+    base tributary-slot-granularity;
+    description
+      "1.25G tributary slot granularity";
+  }
+
+  identity tsg-2.5G {
+    base tributary-slot-granularity;
+    description
+      "2.5G tributary slot granularity";
+  }
+/*
+  identity tsg-1.25Gand2.5G {
+    base tributary-slot-granularity;
+    description
+      "Both 1.25G and 2.5G tributary slot granularity";
+  }
+*/
+  identity tributary-protocol-type {
+    description
+      "Base identity for protocol framing used by tributary signals";
+  }
+
+  identity prot-OTU1 {
+    base tributary-protocol-type;
+    description
+      "OTU1 protocol (2.66G)";
+  }
+/*
+  identity prot-OTU1e {
+    base tributary-protocol-type;
+    description
+      "OTU1e type (11.04G)";
+  }
+
+  identity prot-OTU1f {
+    base tributary-protocol-type;
+    description
+      "OTU1f type (11.27G)";
+  }
+*/
+  identity prot-OTU2 {
+    base tributary-protocol-type;
+    description
+      "OTU2 type (10.70G)";
+  }
+
+  identity prot-OTU2e {
+    base tributary-protocol-type;
+    description
+      "OTU2e type (11.09G)";
+  }
+/*
+  identity prot-OTU2f {
+    base tributary-protocol-type;
+    description
+      "OTU2f type (11.31G)";
+  }
+*/
+  identity prot-OTU3 {
+    base tributary-protocol-type;
+    description
+      "OTU3 type (43.01G)";
+  }
+/*
+  identity prot-OTU3e1 {
+    base tributary-protocol-type;
+    description
+      "OTU3e1 type (44.57G)";
+  }
+
+  identity prot-OTU3e2 {
+    base tributary-protocol-type;
+    description
+      "OTU3e2 type (44.58G)";
+  }
+*/
+  identity prot-OTU4 {
+    base tributary-protocol-type;
+    description
+      "OTU4 type (111.80G)";
+  }
+
+  identity prot-OTUCn {
+    base tributary-protocol-type;
+    description
+      "OTUCn type (beyond 100G)";
+  }
+
+  identity prot-ODU0 {
+    base tributary-protocol-type;
+    description
+      "ODU0 protocol (1.24G)";
+  }
+
+  identity prot-ODU1 {
+    base tributary-protocol-type;
+    description
+      "ODU1 protocol (2.49G)";
+  }
+/*
+  identity prot-ODU1e {
+    base tributary-protocol-type;
+    description
+      "ODU1e protocol (10.35G).";
+  }
+
+  identity prot-ODU1f {
+    base tributary-protocol-type;
+    description
+      "ODU1f protocol (10.56G).";
+  }
+*/
+  identity prot-ODU2 {
+    base tributary-protocol-type;
+    description
+      "ODU2 protocol (10.03G)";
+  }
+
+  identity prot-ODU2e {
+    base tributary-protocol-type;
+    description
+      "ODU2e protocol (10.39G)";
+  }
+/*
+  identity prot-ODU2f {
+    base tributary-protocol-type;
+    description
+      "ODU2f protocol (10.60G).";
+  }
+*/
+  identity prot-ODU3 {
+    base tributary-protocol-type;
+    description
+      "ODU3 protocol (40.31G)";
+  }
+/*
+  identity prot-ODU3e1 {
+    base tributary-protocol-type;
+    description
+      "ODU3e1 protocol (41.77G).";
+  }
+
+  identity prot-ODU3e2 {
+    base tributary-protocol-type;
+    description
+      "ODU3e2 protocol (41.78G).";
+  }
+*/
+  identity prot-ODU4 {
+    base tributary-protocol-type;
+    description
+      "ODU4 protocol (104.79G)";
+  }
+
+  identity prot-ODUFlex-cbr {
+    base tributary-protocol-type;
+    description
+      "ODU Flex CBR protocol for transporting constant bit rate
+       signal";
+  }
+
+  identity prot-ODUFlex-gfp {
+    base tributary-protocol-type;
+    description
+      "ODU Flex GFP protocol for transporting stream of packets
+       using Generic Framing Procedure";
+  }
+
+  identity prot-ODUCn {
+    base tributary-protocol-type;
+    description
+      "ODUCn protocol (beyond 100G)";
+  }
+
+  identity prot-1GbE {
+    base tributary-protocol-type;
+    description
+      "1G Ethernet protocol";
+  }
+
+  identity prot-10GbE-LAN {
+    base tributary-protocol-type;
+    description
+      "10G Ethernet LAN protocol";
+  }
+
+  identity prot-40GbE {
+    base tributary-protocol-type;
+    description
+      "40G Ethernet protocol";
+  }
+
+  identity prot-100GbE {
+    base tributary-protocol-type;
+    description
+      "100G Ethernet protocol";
+  }
+
+  identity client-signal {
+    description
+      "Base identity from which specific client signals for the
+       tunnel are derived";
+  }
+
+  identity client-signal-1GbE {
+    base client-signal;
+    description
+      "Client signal type of 1GbE";
+  }
+
+  identity client-signal-10GbE-LAN {
+    base client-signal;
+    description
+      "Client signal type of 10GbE LAN";
+  }
+
+  identity client-signal-10GbE-WAN {
+    base client-signal;
+    description
+      "Client signal type of 10GbE WAN";
+  }
+
+  identity client-signal-40GbE {
+    base client-signal;
+    description
+      "Client signal type of 40GbE";
+  }
+
+  identity client-signal-100GbE {
+    base client-signal;
+    description
+      "Client signal type of 100GbE";
+  }
+
+  identity client-signal-OC3_STM1 {
+    base client-signal;
+    description
+      "Client signal type of OC3 & STM1";
+  }
+
+  identity client-signal-OC12_STM4 {
+    base client-signal;
+    description
+      "Client signal type of OC12 & STM4";
+  }
+
+  identity client-signal-OC48_STM16 {
+    base client-signal;
+    description
+      "Client signal type of OC48 & STM16";
+  }
+
+  identity client-signal-OC192_STM64 {
+    base client-signal;
+    description
+      "Client signal type of OC192 & STM64";
+  }
+
+  identity client-signal-OC768_STM256 {
+    base client-signal;
+    description
+      "Client signal type of OC768 & STM256";
+  }
+
+  identity client-signal-ODU0 {
+    base client-signal;
+    description
+      "Client signal type of ODU0 (1.24G)";
+  }
+
+  identity client-signal-ODU1 {
+    base client-signal;
+    description
+      "ODU1 protocol (2.49G)";
+  }
+
+  identity client-signal-ODU2 {
+    base client-signal;
+    description
+      "Client signal type of ODU2 (10.03G)";
+  }
+
+  identity client-signal-ODU2e {
+    base client-signal;
+    description
+      "Client signal type of ODU2e (10.39G)";
+  }
+
+  identity client-signal-ODU3 {
+    base client-signal;
+    description
+      "Client signal type of ODU3 (40.31G)";
+  }
+/*
+  identity client-signal-ODU3e2 {
+    base client-signal;
+    description
+      "Client signal type of ODU3e2 (41.78G)";
+  }
+*/
+  identity client-signal-ODU4 {
+    base client-signal;
+    description
+      "Client signal type of ODU4 (104.79G)";
+  }
+
+  identity client-signal-ODUflex-cbr {
+    base client-signal;
+    description
+      "Client signal type of ODU Flex CBR";
+  }
+
+  identity client-signal-ODUflex-gfp {
+    base client-signal;
+    description
+      "Client signal type of ODU Flex GFP";
+  }
+
+  identity client-signal-ODUCn {
+    base client-signal;
+    description
+      "Client signal type of ODUCn (beyond 100G)";
+  }
+
+  identity client-signal-FC400 {
+    base client-signal;
+    description
+      "Client signal type of Fibre Channel FC400";
+  }
+
+  identity client-signal-FC800 {
+    base client-signal;
+    description
+      "Client signal type of Fibre Channel FC800";
+  }
+
+  identity client-signal-FICON-4G {
+    base client-signal;
+    description
+      "Client signal type of Fibre Connection 4G";
+  }
+
+  identity client-signal-FICON-8G {
+    base client-signal;
+    description
+      "Client signal type of Fibre Connection 8G";
+  }
+}


### PR DESCRIPTION
Proposed updates to the OTN Topology model (ietf-otn-topology.yang):
- Add OTN augmentations to generic te-bandwidth and te-label information defined in TE Topology
- Move information about available bandwidth and labels within the generic structure defined in TE Topology

Proposed updates to the OTN Types (ietf-otn-types.yang) supporting the changes to the OTN Topology model:
- Add identity definitions for OTU client-signal
- Add `otn-link-bandwidth `and `otn-path-bandwidth `groupings for augmenting the `te-bandwidth `containers with OTN bandwidth information
- Add otn-`label-restriction `grouping to define OTN label restrictions
- Add `otn-link-label `and `otn-path-label `groupings for augmenting the `te-label `containers with OTN label information
