### PR TITLE
Updated ETH services for IETF 103

### DIFF
--- a/YANG/ccamp/Client-signal-yang/ietf-eth-tran-service.tree
+++ b/YANG/ccamp/Client-signal-yang/ietf-eth-tran-service.tree
@@ -1,7 +1,7 @@
 module: ietf-eth-tran-service
     +--rw etht-svc
        +--rw globals
-       |  +--rw etht-svc-bandwidth-profiles* [bandwidth-profile-name]
+       |  +--rw named-bandwidth-profiles* [bandwidth-profile-name]
        |     +--rw bandwidth-profile-name    string
        |     +--rw bandwidth-profile-type?   etht-types:bandwidth-profile-type
        |     +--rw CIR?                      uint64
@@ -11,17 +11,21 @@ module: ietf-eth-tran-service
        |     +--rw color-aware?              boolean
        |     +--rw coupling-flag?            boolean
        +--rw etht-svc-instances* [etht-svc-name]
-          +--rw etht-svc-name            string
-          +--rw etht-svc-descr?          string
-          +--rw etht-svc-type?           etht-types:service-type
-          +--rw access-provider-id?      te-types:te-global-id
-          +--rw access-client-id?        te-types:te-global-id
-          +--rw access-topology-id?      te-types:te-topology-id
+          +--rw etht-svc-name             string
+          +--rw etht-svc-id?              yang:uuid
+          +--rw etht-svc-descr?           string
+          +--rw etht-svc-customer?        string
+          +--rw etht-svc-type?            etht-types:service-type
+          +--rw etht-svc-lifecycle?       etht-types:lifecycle-status
+          +--rw te-topology-identifier
+          |  +--rw provider-id?   te-types:te-global-id
+          |  +--rw client-id?     te-types:te-global-id
+          |  +--rw topology-id?   te-types:te-topology-id
           +--rw etht-svc-access-ports* [access-port-id]
-          |  +--rw access-port-id                           uint16
-          |  +--rw access-node-id?                          te-types:te-node-id
-          |  +--rw access-ltp-id?                           te-types:te-tp-id
-          |  +--rw service-classification-type?             identityref
+          |  +--rw access-port-id                      uint16
+          |  +--rw access-node-id?                     te-types:te-node-id
+          |  +--rw access-ltp-id?                      te-types:te-tp-id
+          |  +--rw service-classification-type?        identityref
           |  +--rw (service-classification)?
           |  |  +--:(port-classification)
           |  |  +--:(vlan-classification)
@@ -39,13 +43,46 @@ module: ietf-eth-tran-service
           |  |           |  +--rw vlan-value?   etht-types:vlanid
           |  |           +--:(vlan-bundling)
           |  |              +--rw vlan-range?   etht-types:vid-range-type
-          |  +--rw split-horizon-group?                     string
+          |  +--rw split-horizon-group?                string
           |  +--rw (direction)?
           |  |  +--:(symmetrical)
-          |  |  |  +--rw ingress-egress-bandwidth-profile-name?   string
+          |  |  |  +--rw ingress-egress-bandwidth-profile
+          |  |  |     +--rw (style)?
+          |  |  |        +--:(named)
+          |  |  |        |  +--rw bandwidth-profile-name?   string
+          |  |  |        +--:(value)
+          |  |  |           +--rw bandwidth-profile-type?   etht-types:bandwidth-profile-type
+          |  |  |           +--rw CIR?                      uint64
+          |  |  |           +--rw CBS?                      uint64
+          |  |  |           +--rw EIR?                      uint64
+          |  |  |           +--rw EBS?                      uint64
+          |  |  |           +--rw color-aware?              boolean
+          |  |  |           +--rw coupling-flag?            boolean
           |  |  +--:(asymmetrical)
-          |  |     +--rw ingress-bandwidth-profile-name?          string
-          |  |     +--rw egress-bandwidth-profile-name?           string
+          |  |     +--rw ingress-bandwidth-profile
+          |  |     |  +--rw (style)?
+          |  |     |     +--:(named)
+          |  |     |     |  +--rw bandwidth-profile-name?   string
+          |  |     |     +--:(value)
+          |  |     |        +--rw bandwidth-profile-type?   etht-types:bandwidth-profile-type
+          |  |     |        +--rw CIR?                      uint64
+          |  |     |        +--rw CBS?                      uint64
+          |  |     |        +--rw EIR?                      uint64
+          |  |     |        +--rw EBS?                      uint64
+          |  |     |        +--rw color-aware?              boolean
+          |  |     |        +--rw coupling-flag?            boolean
+          |  |     +--rw egress-bandwidth-profile
+          |  |        +--rw (style)?
+          |  |           +--:(named)
+          |  |           |  +--rw bandwidth-profile-name?   string
+          |  |           +--:(value)
+          |  |              +--rw bandwidth-profile-type?   etht-types:bandwidth-profile-type
+          |  |              +--rw CIR?                      uint64
+          |  |              +--rw CBS?                      uint64
+          |  |              +--rw EIR?                      uint64
+          |  |              +--rw EBS?                      uint64
+          |  |              +--rw color-aware?              boolean
+          |  |              +--rw coupling-flag?            boolean
           |  +--rw vlan-operations
           |     +--rw (direction)?
           |        +--:(symmetrical)
@@ -53,31 +90,37 @@ module: ietf-eth-tran-service
           |        |     +--rw pop-tags?    uint8
           |        |     +--rw push-tags
           |        |        +--rw outer-tag!
-          |        |        |  +--rw tag-type?     etht-types:eth-tag-type
-          |        |        |  +--rw vlan-value?   etht-types:vlanid
+          |        |        |  +--rw tag-type?      etht-types:eth-tag-type
+          |        |        |  +--rw vlan-value?    etht-types:vlanid
+          |        |        |  +--rw default-pcp?   uint8
           |        |        +--rw second-tag!
-          |        |           +--rw tag-type?     etht-types:eth-tag-type
-          |        |           +--rw vlan-value?   etht-types:vlanid
+          |        |           +--rw tag-type?      etht-types:eth-tag-type
+          |        |           +--rw vlan-value?    etht-types:vlanid
+          |        |           +--rw default-pcp?   uint8
           |        +--:(asymmetrical)
           |           +--rw asymmetrical-operation
           |              +--rw ingress
           |              |  +--rw pop-tags?    uint8
           |              |  +--rw push-tags
           |              |     +--rw outer-tag!
-          |              |     |  +--rw tag-type?     etht-types:eth-tag-type
-          |              |     |  +--rw vlan-value?   etht-types:vlanid
+          |              |     |  +--rw tag-type?      etht-types:eth-tag-type
+          |              |     |  +--rw vlan-value?    etht-types:vlanid
+          |              |     |  +--rw default-pcp?   uint8
           |              |     +--rw second-tag!
-          |              |        +--rw tag-type?     etht-types:eth-tag-type
-          |              |        +--rw vlan-value?   etht-types:vlanid
+          |              |        +--rw tag-type?      etht-types:eth-tag-type
+          |              |        +--rw vlan-value?    etht-types:vlanid
+          |              |        +--rw default-pcp?   uint8
           |              +--rw egress
           |                 +--rw pop-tags?    uint8
           |                 +--rw push-tags
           |                    +--rw outer-tag!
-          |                    |  +--rw tag-type?     etht-types:eth-tag-type
-          |                    |  +--rw vlan-value?   etht-types:vlanid
+          |                    |  +--rw tag-type?      etht-types:eth-tag-type
+          |                    |  +--rw vlan-value?    etht-types:vlanid
+          |                    |  +--rw default-pcp?   uint8
           |                    +--rw second-tag!
-          |                       +--rw tag-type?     etht-types:eth-tag-type
-          |                       +--rw vlan-value?   etht-types:vlanid
+          |                       +--rw tag-type?      etht-types:eth-tag-type
+          |                       +--rw vlan-value?    etht-types:vlanid
+          |                       +--rw default-pcp?   uint8
           +--rw etht-svc-tunnels* [tunnel-name]
           |  +--rw tunnel-name                string
           |  +--rw (svc-multiplexing-tag)?
@@ -93,7 +136,7 @@ module: ietf-eth-tran-service
           |  +--rw sending-rate-low?      uint64
           |  +--rw receiving-rate-high?   uint64
           |  +--rw receiving-rate-low?    uint64
-          +--rw admin-status?            identityref
+          +--rw admin-status?             identityref
           +--ro state
              +--ro operational-state?         identityref
              +--ro provisioning-state?        identityref

--- a/YANG/ccamp/Client-signal-yang/ietf-eth-tran-service.yang
+++ b/YANG/ccamp/Client-signal-yang/ietf-eth-tran-service.yang
@@ -4,9 +4,9 @@ module ietf-eth-tran-service {
 
   prefix "ethtsvc";
 
-	import ietf-yang-types {
-		prefix "yang";
-	}
+  import ietf-yang-types {
+    prefix "yang";
+  }
 
   import ietf-te-types {
     prefix "te-types";
@@ -16,8 +16,8 @@ module ietf-eth-tran-service {
     prefix "etht-types";
   }
 
-	organization
-		"Internet Engineering Task Force (IETF) CCAMP WG";
+  organization
+    "Internet Engineering Task Force (IETF) CCAMP WG";
   contact
     "
       WG List: <mailto:ccamp@ietf.org>
@@ -36,16 +36,16 @@ module ietf-eth-tran-service {
     "This module defines a YANG data model for describing
      the Ethernet transport services.";
 
-	revision 2018-08-30 {
-		description
-			"Initial revision";
-		reference
-			"draft-zheng-ccamp-otn-client-signal-yang";
-	}
+  revision 2018-10-18 {
+    description
+      "Initial revision";
+    reference
+      "draft-zheng-ccamp-otn-client-signal-yang";
+  }
 
   /*
-  Groupings
-  */
+   * Groupings
+   */
 
   grouping vlan-classification {
     description
@@ -94,6 +94,19 @@ module ietf-eth-tran-service {
       description
         "The VLAN ID value to push/swap.";
     }
+/*
+ * To be added: this attribute is used when:
+ * a) the ETH service has only one CoS (as in current version)
+ * b) as a default when a mapping between a given CoS value
+ *    and the PCP value is not defined (in future versions)
+ */
+    leaf default-pcp {
+      type uint8 {
+        range "0..7";
+      }
+      description
+        "The default Priority Code Point (PCP) value to push/swap";
+    }
   }
 
   grouping vlan-operations {
@@ -125,8 +138,8 @@ module ietf-eth-tran-service {
       }
       container second-tag {
         must
-					'../outer-tag/tag-type = "etht-types:s-vlan-tag-type" and ' +
-					'tag-type = "etht-types:c-vlan-tag-type"'
+          '../outer-tag/tag-type = "etht-types:s-vlan-tag-type" and ' +
+          'tag-type = "etht-types:c-vlan-tag-type"'
         {
 
           error-message
@@ -169,26 +182,68 @@ module ietf-eth-tran-service {
           "The same bandwidth profile is used to describe the ingress
           and the egress bandwidth profile.";
 
-        leaf ingress-egress-bandwidth-profile-name {
-          type "string";
+        choice style {
           description
-            "Name of the bandwidth profile.";
+            "Whether the bandwidth profile used in
+             both the ingress and egress direction 
+             is named or defined by value"
+
+          case named {
+            leaf ingress-egress-bandwidth-profile-name {
+              type "string";
+              description
+                "Name of the bandwidth profile used in 
+                 both the ingress and egress direction.";
+            }
+          }
+          case value {
+            container ingress-egress-bandwidth-profile {
+              uses etht-types:etht-bandwidth-profiles;
+            }
+          }
         }
       }
       case asymmetrical {
         description
           "Ingress and egress bandwidth profiles can be specified.";
-        leaf ingress-bandwidth-profile-name {
-          type "string";
+        /* Ingress bandwdith profile */
+        choice style {
           description
-            "Name of the bandwidth profile used in
-             the ingress direction.";
+            "Whether the bandwidth profile used in the ingress
+             direction is named or defined by value"
+
+          case named {
+            leaf ingress-bandwidth-profile-name {
+              type "string";
+              description
+                "Name of the bandwidth profile used in
+                 the ingress direction.";
+            }
+          }
+          case value {
+            container ingress-bandwidth-profile {
+              uses etht-types:etht-bandwidth-profiles;
+            }
+          }
         }
-        leaf egress-bandwidth-profile-name {
-          type "string";
+        /* Egress bandwidth profile */
+        choice style {
           description
-            "Name of the bandwidth profile used in
-             the egress direction.";
+            "Whether the bandwidth profile used in the egress
+             direction is named or defined by value"
+          case named {
+            leaf egress-bandwidth-profile-name {
+              type "string";
+              description
+                "Name of the bandwidth profile used in
+                 the egress direction.";
+            }
+          }
+          case value {
+            container egress-bandwidth-profile {
+              uses etht-types:etht-bandwidth-profiles;
+            }
+          }
         }
       }
     }
@@ -238,8 +293,8 @@ module ietf-eth-tran-service {
         }
         container second-tag {
           must
-						'../outer-tag/tag-type = "etht-types:classify-s-vlan" and ' +
-						'tag-type = "etht-types:classify-c-vlan"'
+            '../outer-tag/tag-type = "etht-types:classify-s-vlan" and ' +
+            'tag-type = "etht-types:classify-c-vlan"'
           {
 
             error-message
@@ -267,12 +322,12 @@ module ietf-eth-tran-service {
     }
 
 /*
-	Open issue: can we constraints it to be used only with mp services?
-*/
-		leaf split-horizon-group {
-			type string;
-			description "Identify a split horizon group";
-		}
+ * Open issue: can we constraints it to be used only with mp services?
+ */
+    leaf split-horizon-group {
+      type string;
+      description "Identify a split horizon group";
+    }
 
     uses bandwidth-profiles;
 
@@ -325,11 +380,11 @@ module ietf-eth-tran-service {
          placeholder to support proprietary multiplexing
          (for further discussion)
         */
-			}
+      }
 
       case none {
         /* no additional information is needed */
-			}
+      }
 
       case vlan-tag {
         /*
@@ -338,24 +393,24 @@ module ietf-eth-tran-service {
           by the VLAN classification and operations configured in the
           etht-svc-access-parameters grouping
         */
-			}
+      }
 
       case pw {
         /* to be completed (for further discussion) */
-			}
+      }
     }
 
 /*
-	Open issue: can we constraints it to be used only with mp services?
-*/
-		leaf src-split-horizon-group {
-			type string;
-			description "Identify a split horizon group at the Tunnel source TTP";
-		}
-		leaf dst-split-horizon-group {
-			type string;
-			description "Identify a split horizon group at the Tunnel destination TTP";
-		}
+ * Open issue: can we constraints it to be used only with mp services?
+ */
+    leaf src-split-horizon-group {
+      type string;
+      description "Identify a split horizon group at the Tunnel source TTP";
+    }
+    leaf dst-split-horizon-group {
+      type string;
+      description "Identify a split horizon group at the Tunnel destination TTP";
+    }
   }
 
   grouping te-topology-identifier {
@@ -377,57 +432,57 @@ module ietf-eth-tran-service {
     }
   }
 
-	grouping  etht-svc-pm-threshold_config {
-		description
-			"Configuraiton parameters for Ethernet service PM thresholds.";
+  grouping  etht-svc-pm-threshold_config {
+    description
+      "Configuraiton parameters for Ethernet service PM thresholds.";
 
-		leaf sending-rate-high {
-			type uint64;
-			description
-				"High threshold of packet sending rate in kbps.";
-		}
-		leaf sending-rate-low {
-			type uint64;
-			description
-				"Low threshold of packet sending rate in kbps.";
-		}
-		leaf receiving-rate-high {
-			type uint64;
-			description
-				"High threshold of packet receiving rate in kbps.";
-		}
-		leaf receiving-rate-low {
-			type uint64;
-			description
-				"Low threshold of packet receiving rate in kbps.";
-		}
-	}	
+    leaf sending-rate-high {
+      type uint64;
+      description
+        "High threshold of packet sending rate in kbps.";
+    }
+    leaf sending-rate-low {
+      type uint64;
+      description
+        "Low threshold of packet sending rate in kbps.";
+    }
+    leaf receiving-rate-high {
+      type uint64;
+      description
+        "High threshold of packet receiving rate in kbps.";
+    }
+    leaf receiving-rate-low {
+      type uint64;
+      description
+        "Low threshold of packet receiving rate in kbps.";
+    }
+  }
 
-	grouping  etht-svc-pm-stats {
-		description
-			"Ethernet service PM statistics.";
+  grouping  etht-svc-pm-stats {
+    description
+      "Ethernet service PM statistics.";
 
-		leaf sending-rate-too-high {
-			type uint32;
-			description
-				"Counter that indicates the number of times the sending rate is above the high threshold";
-		}
-		leaf sending-rate-too-low {
-			type uint32;
-			description
-				"Counter that indicates the number of times the sending rate is below the low threshold";
-		}
-		leaf receiving-rate-too-high {
-			type uint32;
-			description
-				"Counter that indicates the number of times the receiving rate is above the high threshold";
-		}
-		leaf receiving-rate-too-low {
-			type uint32;
-			description
-				"Counter that indicates the number of times the receiving rate is below the low threshold";
-		}
-	}	
+    leaf sending-rate-too-high {
+      type uint32;
+      description
+        "Counter that indicates the number of times the sending rate is above the high threshold";
+    }
+    leaf sending-rate-too-low {
+      type uint32;
+      description
+        "Counter that indicates the number of times the sending rate is below the low threshold";
+    }
+    leaf receiving-rate-too-high {
+      type uint32;
+      description
+        "Counter that indicates the number of times the receiving rate is above the high threshold";
+    }
+    leaf receiving-rate-too-low {
+      type uint32;
+      description
+        "Counter that indicates the number of times the receiving rate is below the low threshold";
+    }
+  }  
 
   grouping  etht-svc-instance_config {
     description
@@ -436,32 +491,51 @@ module ietf-eth-tran-service {
     leaf etht-svc-name {
       type string;
       description
-        "Name of the p2p ETH transport service.";
+        "Name of the ETH transport service.";
     }
 
-		leaf etht-svc-descr {
-			type string;
-			description
-				"Description of the ETH transport service.";
-		}
+    leaf etht-svc-id {
+      type yang:uuid;
+      description
+        "Universally Unique IDentifier (UUID) of the ETH transport service.";
+    }
 
- 		leaf etht-svc-type {
-			type etht-types:service-type;
-			description
-				"Type of Ethernet service (p2p, mp2mp or rmp).";
-			/* Add default as p2p */
-		}
+    leaf etht-svc-descr {
+      type string;
+      description
+        "Description of the ETH transport service.";
+    }
 
-		uses te-topology-identifier;
+    leaf etht-svc-customer {
+      type string;
+      description
+        "Customer of the ETH transport service.";
+    }
+
+     leaf etht-svc-type {
+      type etht-types:service-type;
+      description
+        "Type of ETH transport service (p2p, mp2mp or rmp).";
+      /* Add default as p2p */
+    }
+
+     leaf etht-svc-lifecycle {
+      type etht-types:lifecycle-status;
+      description
+        "Lifecycle state of ETH transport service.";
+      /* Add default as installed  */
+    }
+
+    uses te-topology-identifier;
 
     list etht-svc-access-ports {
       key access-port-id;
       min-elements "1";
 /*
-	Open Issue:
-		Is it possible to limit the max-elements only for p2p services?
+  Open Issue:
+    Is it possible to limit the max-elements only for p2p services?
 
-			max-elements "2";
+      max-elements "2";
 */
       description
         "List of the ETH trasport services access port instances.";
@@ -481,17 +555,17 @@ module ietf-eth-tran-service {
 
       uses etht-svc-tunnel-parameters;
     }
-		container pm-config {
-			description
-				"ETH service performance monitoring";
-				 
-			leaf pm-enable {
-				type boolean;
-				description 
-					"Boolean value indicating whether PM is enabled.";
-			}
-			uses etht-svc-pm-threshold_config;	
-		}
+    container pm-config {
+      description
+        "ETH service performance monitoring";
+         
+      leaf pm-enable {
+        type boolean;
+        description 
+          "Boolean value indicating whether PM is enabled.";
+      }
+      uses etht-svc-pm-threshold_config;  
+    }
     leaf admin-status {
       type identityref {
         base te-types:tunnel-state-type;
@@ -499,18 +573,18 @@ module ietf-eth-tran-service {
       default te-types:tunnel-state-up;
       description "ETH service administrative state.";
     }
-	}
+  }
 
   grouping  etht-svc-instance_state {
     description
       "State parameters for Ethernet services.";
 
     leaf operational-state {
-	  type identityref {
+    type identityref {
         base te-types:tunnel-state-type;
       }
       default te-types:tunnel-state-up;
-	  description "ETH service operational state.";
+    description "ETH service operational state.";
     }
     leaf provisioning-state {
       type identityref {
@@ -518,34 +592,39 @@ module ietf-eth-tran-service {
       }
       description "ETH service provisioning state.";
     }
-		leaf creation-time {
-			type yang:date-and-time;
-			description
-				"Time of ETH service creation.";
-		}
-		leaf last-updated-time {
-			type yang:date-and-time;
-			description
-				"Time of ETH service last update.";
-		}
-		uses etht-svc-pm-stats;
+    leaf creation-time {
+      type yang:date-and-time;
+      description
+        "Time of ETH service creation.";
+    }
+    leaf last-updated-time {
+      type yang:date-and-time;
+      description
+        "Time of ETH service last update.";
+    }
+    uses etht-svc-pm-stats;
   }
 
   /*
-  Data nodes
-  */
+   * Data nodes
+   */
 
   container etht-svc {
     description
       "ETH transport services.";
 
     container globals {
-      list etht-svc-bandwidth-profiles {
+      list named-bandwidth-profiles {
         key bandwidth-profile-name;
         description
-          "List of bandwidth profile templates used by
+          "List of named bandwidth profiles used by
            Ethernet services.";
 
+        leaf bandwidth-profile-name {
+          type string;
+          description
+            "Name of the bandwidth profile.";
+        }
         uses etht-types:etht-bandwidth-profiles;
       }
     }

--- a/YANG/ccamp/Client-signal-yang/ietf-eth-tran-service.yang
+++ b/YANG/ccamp/Client-signal-yang/ietf-eth-tran-service.yang
@@ -1,6 +1,6 @@
 module ietf-eth-tran-service {
 
-  namespace "urn:ietf:params:xml:ns:yang:ietf-eth-tran-svc";
+  namespace "urn:ietf:params:xml:ns:yang:ietf-eth-tran-service";
 
   prefix "ethtsvc";
 
@@ -169,6 +169,32 @@ module ietf-eth-tran-service {
     }
   }
 
+  grouping named-or-value-bandwidth-profile {
+    description
+      "A grouping to configure a bandwdith profile either by
+       referencing a named bandwidth profile or by
+       configuring the values of the bandwidth profile attributes.";
+    choice style {
+      description
+        "Whether the bandwidth profile is named or defined by value";
+
+      case named {
+        description
+          "Named bandwidth profile.";
+        leaf bandwidth-profile-name {
+          type "string";
+          description
+            "Name of the bandwidth profile.";
+        }
+      }
+      case value {
+        description
+          "Bandwidth profile configured by value.";
+        uses etht-types:etht-bandwidth-profiles;
+      }
+    }
+  }
+
   grouping bandwidth-profiles {
     description
       "A grouping which represent bandwidth profile configuration.";
@@ -179,71 +205,26 @@ module ietf-eth-tran-service {
          asymmetrical";
       case symmetrical {
         description
-          "The same bandwidth profile is used to describe the ingress
-          and the egress bandwidth profile.";
-
-        choice style {
+          "The same bandwidth profile is used to describe both 
+           the ingress and the egress bandwidth profile.";
+        container ingress-egress-bandwidth-profile {
           description
-            "Whether the bandwidth profile used in
-             both the ingress and egress direction 
-             is named or defined by value"
-
-          case named {
-            leaf ingress-egress-bandwidth-profile-name {
-              type "string";
-              description
-                "Name of the bandwidth profile used in 
-                 both the ingress and egress direction.";
-            }
-          }
-          case value {
-            container ingress-egress-bandwidth-profile {
-              uses etht-types:etht-bandwidth-profiles;
-            }
-          }
+            "The bandwdith profile used in both directions.";
+          uses named-or-value-bandwidth-profile;
         }
       }
       case asymmetrical {
         description
           "Ingress and egress bandwidth profiles can be specified.";
-        /* Ingress bandwdith profile */
-        choice style {
+        container ingress-bandwidth-profile {
           description
-            "Whether the bandwidth profile used in the ingress
-             direction is named or defined by value"
-
-          case named {
-            leaf ingress-bandwidth-profile-name {
-              type "string";
-              description
-                "Name of the bandwidth profile used in
-                 the ingress direction.";
-            }
-          }
-          case value {
-            container ingress-bandwidth-profile {
-              uses etht-types:etht-bandwidth-profiles;
-            }
-          }
+            "The bandwdith profile used in the ingress direction.";
+          uses named-or-value-bandwidth-profile;
         }
-        /* Egress bandwidth profile */
-        choice style {
+        container egress-bandwidth-profile {
           description
-            "Whether the bandwidth profile used in the egress
-             direction is named or defined by value"
-          case named {
-            leaf egress-bandwidth-profile-name {
-              type "string";
-              description
-                "Name of the bandwidth profile used in
-                 the egress direction.";
-            }
-          }
-          case value {
-            container egress-bandwidth-profile {
-              uses etht-types:etht-bandwidth-profiles;
-            }
-          }
+            "The bandwdith profile used in the egress direction.";
+          uses named-or-value-bandwidth-profile;
         }
       }
     }
@@ -332,6 +313,8 @@ module ietf-eth-tran-service {
     uses bandwidth-profiles;
 
     container vlan-operations {
+      description
+        "Configuration of VLAN operations.";
       choice direction {
         description
           "Whether the VLAN operations are symmetrical or
@@ -410,25 +393,6 @@ module ietf-eth-tran-service {
     leaf dst-split-horizon-group {
       type string;
       description "Identify a split horizon group at the Tunnel destination TTP";
-    }
-  }
-
-  grouping te-topology-identifier {
-    leaf access-provider-id {
-      type te-types:te-global-id;
-      description
-        "An identifier to uniquely identify a provider.";
-    }
-    leaf access-client-id {
-      type te-types:te-global-id;
-      description
-        "An identifier to uniquely identify a client.";
-    }
-    leaf access-topology-id {
-      type te-types:te-topology-id;
-      description
-        "Identifies the topology the
-        service access ports belong to.";
     }
   }
 
@@ -526,7 +490,7 @@ module ietf-eth-tran-service {
       /* Add default as installed  */
     }
 
-    uses te-topology-identifier;
+    uses te-types:te-topology-identifier;
 
     list etht-svc-access-ports {
       key access-port-id;
@@ -614,6 +578,8 @@ module ietf-eth-tran-service {
       "ETH transport services.";
 
     container globals {
+      description
+        "Globals Ethernet configuration data container";
       list named-bandwidth-profiles {
         key bandwidth-profile-name;
         description

--- a/YANG/ccamp/Client-signal-yang/ietf-eth-tran-types.yang
+++ b/YANG/ccamp/Client-signal-yang/ietf-eth-tran-types.yang
@@ -1,11 +1,11 @@
 module ietf-eth-tran-types {
 
-	namespace "urn:ietf:params:xml:ns:yang:ietf-eth-tran-types";
+  namespace "urn:ietf:params:xml:ns:yang:ietf-eth-tran-types";
 
-	prefix "etht-types";
+  prefix "etht-types";
 
-	organization
-		"Internet Engineering Task Force (IETF) CCAMP WG";
+  organization
+    "Internet Engineering Task Force (IETF) CCAMP WG";
   contact
     "
       WG List: <mailto:ccamp@ietf.org>
@@ -20,259 +20,283 @@ module ietf-eth-tran-types {
         Giuseppe Fioccola (giuseppe.fioccola@telecomitalia.it);
     ";
 
-	description
-		"This module defines the ETH transport types.";
+  description
+    "This module defines the ETH transport types.";
 
-	revision 2018-08-30 {
-		description
-			"Initial revision";
-		reference
-			"draft-zheng-ccamp-client-signal-yang";
-	}
+  revision 2018-10-18 {
+    description
+      "Initial Revision";
+    reference
+      "draft-zheng-ccamp-client-signal-yang";
+  }
 
-	/*
-	Identities
-	*/
+  /*
+   * Identities
+   */
 
-	identity eth-vlan-tag-type {
-		description
-			"ETH VLAN tag type.";
-	}
+  identity eth-vlan-tag-type {
+    description
+      "ETH VLAN tag type.";
+  }
 
-	identity c-vlan-tag-type {
-		base eth-vlan-tag-type;
-		description
-			"802.1Q Customer VLAN";
-	}
+  identity c-vlan-tag-type {
+    base eth-vlan-tag-type;
+    description
+      "802.1Q Customer VLAN";
+  }
 
-	identity s-vlan-tag-type {
-		base eth-vlan-tag-type;
-		description
-		"802.1Q Service VLAN (QinQ)";
-	}
+  identity s-vlan-tag-type {
+    base eth-vlan-tag-type;
+    description
+      "802.1Q Service VLAN (QinQ)";
+  }
 
-	identity service-classification-type {
-		description
-			"Service classification.";
-	}
+  identity service-classification-type {
+    description
+      "Service classification.";
+  }
 
-	identity port-classification {
-		base service-classification-type;
-		description
-			"Port classification.";
-	}
+  identity port-classification {
+    base service-classification-type;
+    description
+      "Port classification.";
+  }
 
-	identity vlan-classification {
-		base service-classification-type;
-		description
-			"VLAN classification.";
-	}
+  identity vlan-classification {
+    base service-classification-type;
+    description
+      "VLAN classification.";
+  }
 
-	identity eth-vlan-tag-classify {
-		description
-			"VLAN tag classification.";
-	}
+  identity eth-vlan-tag-classify {
+    description
+      "VLAN tag classification.";
+  }
 
-	identity classify-c-vlan {
-		base eth-vlan-tag-classify;
-		description
-			"Classify 802.1Q Customer VLAN tag.
-			 Only C-tag type is accepted";
-	}
+  identity classify-c-vlan {
+    base eth-vlan-tag-classify;
+    description
+      "Classify 802.1Q Customer VLAN tag.
+       Only C-tag type is accepted";
+  }
 
-	identity classify-s-vlan {
-		base eth-vlan-tag-classify;
-		description
-			"Classify 802.1Q Service VLAN (QinQ) tag. 
-			 Only S-tag type is accepted";
-	}
+  identity classify-s-vlan {
+    base eth-vlan-tag-classify;
+    description
+      "Classify 802.1Q Service VLAN (QinQ) tag. 
+       Only S-tag type is accepted";
+  }
 
-	identity classify-s-or-c-vlan {
-		base eth-vlan-tag-classify;
-		description
-			"Classify S-VLAN or C-VLAN tag-classify.
-			 Either tag is accepted";
-	}
+  identity classify-s-or-c-vlan {
+    base eth-vlan-tag-classify;
+    description
+      "Classify S-VLAN or C-VLAN tag-classify.
+       Either tag is accepted";
+  }
 
-	identity bandwidth-profile-type {
-		description
-			"Bandwidth Profile Types";
-	}
+  identity bandwidth-profile-type {
+    description
+      "Bandwidth Profile Types";
+  }
 
-	identity mef-10-bwp {
-		base bandwidth-profile-type;
-		description
-			"MEF 10 Bandwidth Profile";
-	}
+  identity mef-10-bwp {
+    base bandwidth-profile-type;
+    description
+      "MEF 10 Bandwidth Profile";
+  }
 
-	identity rfc-2697-bwp {
-		base bandwidth-profile-type;
-		description
-			"RFC 2697 Bandwidth Profile";
-	}
+  identity rfc-2697-bwp {
+    base bandwidth-profile-type;
+    description
+      "RFC 2697 Bandwidth Profile";
+  }
 
-	identity rfc-2698-bwp {
-		base bandwidth-profile-type;
-		description
-			"RFC 2698 Bandwidth Profile";
-	}
+  identity rfc-2698-bwp {
+    base bandwidth-profile-type;
+    description
+      "RFC 2698 Bandwidth Profile";
+  }
 
-	identity rfc-4115-bwp {
-		base bandwidth-profile-type;
-		description
-			"RFC 4115 Bandwidth Profile";
-	}
+  identity rfc-4115-bwp {
+    base bandwidth-profile-type;
+    description
+      "RFC 4115 Bandwidth Profile";
+  }
 
-	identity service-type {
-		description
-			"Type of Ethernet service.";
-	}
-	
-	identity p2p-svc {
-		base service-type;
-		description
-			"Ethernet point-to-point service (EPL, EVPL).";
-	}
+  identity service-type {
+    description
+      "Type of Ethernet service.";
+  }
 
-	identity rmp-svc {
-		base service-type;
-		description
-			"Ethernet rooted-multitpoint service (E-TREE, EP-TREE).";
-	}
+  identity p2p-svc {
+    base service-type;
+    description
+      "Ethernet point-to-point service (EPL, EVPL).";
+  }
 
+  identity rmp-svc {
+    base service-type;
+    description
+      "Ethernet rooted-multitpoint service (E-TREE, EP-TREE).";
+  }
 
-	identity mp2mp-svc {
-		base service-type;
-		description
-			"Ethernet multipoint-to-multitpoint service (E-LAN, EP-LAN).";
-	}
+  identity mp2mp-svc {
+    base service-type;
+    description
+      "Ethernet multipoint-to-multitpoint service (E-LAN, EP-LAN).";
+  }
 
-	/*
-	Type Definitions
-	*/
+  identity lifecycle-status {
+    description
+      "Lifecycle Status.";
+  }
 
-	typedef eth-tag-type {
-		type identityref {
-			base eth-vlan-tag-type;
-		}
-		description
-			"Identifies a specific ETH VLAN tag type.";
-	}
+  identity installed {
+    base lifecycle-status;
+    description
+      "Installed.";
+  }
 
-	typedef eth-tag-classify {
-		type identityref {
-			base eth-vlan-tag-classify;
-		}
-		description
-			"Identifies a specific VLAN tag classification.";
-	}
+  identity planned {
+    base lifecycle-status;
+    description
+      "Planned.";
+  }
 
-	typedef vlanid {
-		type uint16 {
-			range "1..4094";
-		}
-		description
-			"The 12-bit VLAN-ID used in the VLAN Tag header.";
-	}
+  identity pending-removal {
+    base lifecycle-status;
+    description
+      "Pending Removal.";
+  }
 
-	typedef vid-range-type {
-		type string {
-			pattern	"([1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?" +
-							"(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
-		}
-		description
-			"A list of VLAN Ids, or non overlapping VLAN ranges, in
-			ascending order, between 1 and 4094.
-		
-				This type is used to match an ordered list of VLAN Ids, or
-				contiguous ranges of VLAN Ids. Valid VLAN Ids must be in the 
-				range 1 to 4094, and included in the list in non overlapping
-				ascending order.
-			
-				For example: 1,10-100,50,500-1000";
-	}
-	
-	typedef bandwidth-profile-type {
-		type identityref {
-			base bandwidth-profile-type;
-		}
-		description
-			"Identifies a specific Bandwidth Profile type.";
-	}
+  /*
+   * Type Definitions
+   */
 
-	typedef service-type {
-		type identityref {
-			base service-type;
-		}
-		description
-			"Identifies the type of Ethernet service.";
-	}
-	
-	/*
-	Grouping Definitions
-	*/	
-	grouping etht-bandwidth-profiles {
-		description
-			"Bandwidth profile configuration paramters.";
+  typedef eth-tag-type {
+    type identityref {
+      base eth-vlan-tag-type;
+    }
+    description
+      "Identifies a specific ETH VLAN tag type.";
+  }
 
-		leaf bandwidth-profile-name {
-			type string;
-			description
-				"Name of the bandwidth profile.";
-		}
-		leaf bandwidth-profile-type {
-			type etht-types:bandwidth-profile-type;
-			description
-				"The type of bandwidth profile.";
-		}
-		leaf CIR {
-			type uint64;
-			description
-				"Committed Information Rate in Kbps";
-		}
-		leaf CBS {
-			type uint64;
-			description
-				"Committed Burst Size in in KBytes";
-		}
-		leaf EIR {
-			type uint64;
-			/*
-				Need to indicate that EIR is not supported by RFC 2697
-				
-				must
-					'../bw-profile-type = "mef-10-bwp" or ' +
-					'../bw-profile-type = "rfc-2698-bwp" or ' +
-					'../bw-profile-type = "rfc-4115-bwp"'
+  typedef eth-tag-classify {
+    type identityref {
+      base eth-vlan-tag-classify;
+    }
+    description
+      "Identifies a specific VLAN tag classification.";
+  }
 
-				must
-					'../bw-profile-type != "rfc-2697-bwp"'
-			*/
-			description
-				"Excess Information Rate in Kbps
-				 In case of RFC 2698, PIR = CIR + EIR";
-		}
-		leaf EBS {
-			type uint64;
-			description
-				"Excess Burst Size in KBytes.
-				 In case of RFC 2698, PBS = CBS + EBS";
-		}
-		leaf color-aware {
-			type boolean;
-			description
-				"Indicates weather the color-mode is color-aware or color-blind.";
-		}
-		leaf coupling-flag {
-			type boolean;
-			/*
-				Need to indicate that Coupling Flag is defined only for MEF 10
-				
-				must
-					'../bw-profile-type = "mef-10-bwp"'
-			*/
-			description
-				"Coupling Flag.";
-		}
-	}
+  typedef vlanid {
+    type uint16 {
+      range "1..4094";
+    }
+    description
+      "The 12-bit VLAN-ID used in the VLAN Tag header.";
+  }
+
+  typedef vid-range-type {
+    type string {
+      pattern "([1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?" +
+              "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
+    }
+    description
+      "A list of VLAN Ids, or non overlapping VLAN ranges, in
+       ascending order, between 1 and 4094.
+
+       This type is used to match an ordered list of VLAN Ids, or
+       contiguous ranges of VLAN Ids. Valid VLAN Ids must be in the 
+       range 1 to 4094, and included in the list in non overlapping
+       ascending order.
+
+       For example: 1,10-100,50,500-1000";
+  }
+
+  typedef bandwidth-profile-type {
+    type identityref {
+      base bandwidth-profile-type;
+    }
+    description
+      "Identifies a specific Bandwidth Profile type.";
+  }
+
+  typedef service-type {
+    type identityref {
+      base service-type;
+    }
+    description
+      "Identifies the type of Ethernet service.";
+  }
+
+  typedef lifecycle-status {
+    type identityref {
+      base lifecycle-status;
+    }
+    description
+      "Identifies the lLifecycle Status .";
+  }
+
+  /*
+   * Grouping Definitions
+   */
+
+  grouping etht-bandwidth-profiles {
+    description
+      "Bandwidth profile configuration paramters.";
+
+    leaf bandwidth-profile-type {
+      type etht-types:bandwidth-profile-type;
+      description
+        "The type of bandwidth profile.";
+    }
+    leaf CIR {
+      type uint64;
+      description
+        "Committed Information Rate in Kbps";
+    }
+    leaf CBS {
+      type uint64;
+      description
+        "Committed Burst Size in in KBytes";
+    }
+    leaf EIR {
+      type uint64;
+      /* Need to indicate that EIR is not supported by RFC 2697
+
+      must
+        '../bw-profile-type = "mef-10-bwp" or ' +
+        '../bw-profile-type = "rfc-2698-bwp" or ' +
+        '../bw-profile-type = "rfc-4115-bwp"'
+
+      must
+        '../bw-profile-type != "rfc-2697-bwp"'
+      */
+      description
+        "Excess Information Rate in Kbps
+         In case of RFC 2698, PIR = CIR + EIR";
+    }
+    leaf EBS {
+      type uint64;
+      description
+        "Excess Burst Size in KBytes.
+          In case of RFC 2698, PBS = CBS + EBS";
+    }
+    leaf color-aware {
+      type boolean;
+      description
+        "Indicates weather the color-mode is color-aware or color-blind.";
+    }
+    leaf coupling-flag {
+      type boolean;
+      /* Need to indicate that Coupling Flag is defined only for MEF 10
+
+      must
+        '../bw-profile-type = "mef-10-bwp"'
+      */
+      description
+        "Coupling Flag.";
+    }
+  }
 }


### PR DESCRIPTION
Update ETH service YANG models (ietf-eth-tran-types.yang and ietf-eth-tran-service.yang) to address some offline feedbacks:
- added default-pcp configuration
- added etht-svc-id configuration
- added etht-svc-customer configuration
- added etht-svc-lifecycle configuration
- added the possibility to configure bandwdith profiles by name or by value
- replaced the te-topology-identifier grouping by the te-types:te-topology-identifier grouping

Model compiled and tree (ietf-eth-tran-service.tree) updated
