### PR TITLE
Updated transparent client services for IETF 103

### DIFF
--- a/YANG/ccamp/Client-signal-yang/ietf-trans-client-service.tree
+++ b/YANG/ccamp/Client-signal-yang/ietf-trans-client-service.tree
@@ -1,0 +1,22 @@
+module: ietf-trans-client-service
+    +--rw client-svc
+       +--rw client-svc-instances* [client-svc-name]
+          +--rw client-svc-name           string
+          +--rw client-svc-descr?         string
+          +--rw te-topology-identifier
+          |  +--rw provider-id?   te-types:te-global-id
+          |  +--rw client-id?     te-types:te-global-id
+          |  +--rw topology-id?   te-types:te-topology-id
+          +--rw src-access-ports
+          |  +--rw access-node-id?   te-types:te-node-id
+          |  +--rw access-ltp-id?    te-types:te-tp-id
+          |  +--rw client-signal?    identityref
+          +--rw dst-access-ports
+          |  +--rw access-node-id?   te-types:te-node-id
+          |  +--rw access-ltp-id?    te-types:te-tp-id
+          |  +--rw client-signal?    identityref
+          +--rw svc-tunnels* [tunnel-name]
+          |  +--rw tunnel-name    string
+          +--rw admin-status?             identityref
+          +--ro operational-state?        identityref
+          +--ro provisioning-state?       identityref

--- a/YANG/ccamp/Client-signal-yang/ietf-trans-client-service.yang
+++ b/YANG/ccamp/Client-signal-yang/ietf-trans-client-service.yang
@@ -9,8 +9,8 @@ module ietf-trans-client-service {
     prefix "te-types";
   }
 
-  import ietf-otn-types {
-    prefix "otn-types";
+  import ietf-l1-service-types {
+    prefix "l1-svc-types";
   }
 
   organization
@@ -32,16 +32,17 @@ module ietf-trans-client-service {
     "This module defines a YANG data model for describing
      simple transport client services.";
 
-  revision 2018-02-09 {
+  revision 2018-10-19 {
     description
       "Initial version";
     reference
-      "ADD REFERENCE HERE";
+      "draft-zheng-ccamp-client-signal-yang";
   }
 
   /*
    * Groupings
    */
+
   grouping client-svc-access-parameters {
     description
       "Transport client services access parameters";
@@ -52,22 +53,20 @@ module ietf-trans-client-service {
         "The identifier of the access node in the underlying
          transport topology.";
     }
-
     leaf access-ltp-id {
       type te-types:te-tp-id;
       description
         "The TE link termination point identifier, used together with
          access-node-id to identify the access LTP.";
     }
-
     leaf client-signal {
       type identityref {
-        base otn-types:client-signal;
+        base l1-svc-types:protocol-type;
       }
       description
         "Identifiies the client signal type associated with this port";
-                }
     }
+  }
 
   grouping client-svc-tunnel-parameters {
     description
@@ -80,28 +79,6 @@ module ietf-trans-client-service {
     }
   }
 
-  grouping te-topology-identifier {
-    description
-      "description";
-    leaf access-provider-id {
-      type te-types:te-global-id;
-      description
-        "An identifier to uniquely identify a provider.";
-    }
-
-    leaf access-client-id {
-      type te-types:te-global-id;
-      description
-        "An identifier to uniquely identify a client.";
-    }
-
-    leaf access-topology-id {
-      type te-types:te-topology-id;
-      description
-        "Identifies the topology the service access ports belong to.";
-    }
-  }
-
   grouping  client-svc-instance_config {
     description
       "Configuraiton parameters for client services.";
@@ -111,15 +88,28 @@ module ietf-trans-client-service {
       description
         "Name of the p2p transport client service.";
     }
-
     leaf client-svc-descr {
       type string;
       description
         "Description of the transport client service.";
     }
-
-        uses te-topology-identifier;
-
+    uses te-types:te-topology-identifier;
+    container src-access-ports {
+      description
+        "Source access port of a client service.";
+      uses client-svc-access-parameters;
+    }
+    container dst-access-ports {
+      description
+        "Destination access port of a client service.";
+      uses client-svc-access-parameters;
+    }
+    list svc-tunnels {
+      key tunnel-name;
+      description
+        "List of the TE Tunnels supporting the client service.";
+      uses client-svc-tunnel-parameters;
+    }
     leaf admin-status {
       type identityref {
         base te-types:tunnel-state-type;
@@ -127,25 +117,6 @@ module ietf-trans-client-service {
       default te-types:tunnel-state-up;
       description "Client service administrative state.";
     }
-
-    container src-access-ports {
-      description
-        "Source access port of a client service.";
-      uses client-svc-access-parameters;
-    }
-
-        container dst-access-ports {
-          description
-                "Destination access port of a client service.";
-          uses client-svc-access-parameters;
-        }
-
-        list svc-tunnels {
-          key tunnel-name;
-          description
-                "List of the TE Tunnels supporting the client service.";
-          uses client-svc-tunnel-parameters;
-        }
   }
 
   grouping  client-svc-instance_state {


### PR DESCRIPTION
Update transparent client service YANG models (ietf-trans-client-service.yang) to address some offline feedbacks:

- replaced the te-topology-identifier grouping by the te-types:te-topology-identifier grouping
- replaced the otn-types:client-signal base identity by the l1-svc-types:protocol-type base identity
- moved the admin-status leaf

Model compiled and tree (ietf-trans-client-service.tree) updated