### PR TITLE
Proposed OTN model updates to align with ietf-te-types@2018-10-08.yang

### DIFF
--- a/YANG/ccamp/otn-topology/ietf-otn-topology.tree
+++ b/YANG/ccamp/otn-topology/ietf-otn-topology.tree
@@ -120,6 +120,9 @@ module: ietf-otn-topology
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:label-restrictions/tet:label-restriction/tet:label-step/tet:technology:
+    +--:(otn)
+       +--rw otn-step?   uint16
   augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
     +--:(otn)
        +--rw tpn?       uint16
@@ -163,6 +166,9 @@ module: ietf-otn-topology
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:from/tet:label-restrictions/tet:label-restriction/tet:label-step/tet:technology:
+    +--:(otn)
+       +--rw otn-step?   uint16
   augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:to/tet:label-restrictions/tet:label-restriction:
     +--rw range-type?   identityref
     +--rw tsg?          identityref
@@ -181,6 +187,9 @@ module: ietf-otn-topology
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:to/tet:label-restrictions/tet:label-restriction/tet:label-step/tet:technology:
+    +--:(otn)
+       +--rw otn-step?   uint16
   augment /nw:networks/nw:network/nw:node/tet:te/tet:te-node-attributes/tet:connectivity-matrices/tet:connectivity-matrix/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
     +--:(otn)
        +--rw tpn?       uint16
@@ -224,6 +233,9 @@ module: ietf-otn-topology
           |  +--ro tpn?   uint16
           +--:(tributary-slot)
              +--ro ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:label-restrictions/tet:label-restriction/tet:label-step/tet:technology:
+    +--:(otn)
+       +--ro otn-step?   uint16
   augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
     +--:(otn)
        +--ro tpn?       uint16
@@ -267,6 +279,9 @@ module: ietf-otn-topology
           |  +--ro tpn?   uint16
           +--:(tributary-slot)
              +--ro ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:from/tet:label-restrictions/tet:label-restriction/tet:label-step/tet:technology:
+    +--:(otn)
+       +--ro otn-step?   uint16
   augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:to/tet:label-restrictions/tet:label-restriction:
     +--ro range-type?   identityref
     +--ro tsg?          identityref
@@ -285,6 +300,9 @@ module: ietf-otn-topology
           |  +--ro tpn?   uint16
           +--:(tributary-slot)
              +--ro ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:to/tet:label-restrictions/tet:label-restriction/tet:label-step/tet:technology:
+    +--:(otn)
+       +--ro otn-step?   uint16
   augment /nw:networks/nw:network/nw:node/tet:te/tet:information-source-entry/tet:connectivity-matrices/tet:connectivity-matrix/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
     +--:(otn)
        +--ro tpn?       uint16
@@ -328,6 +346,9 @@ module: ietf-otn-topology
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:label-restrictions/tet:label-restriction/tet:label-step/tet:technology:
+    +--:(otn)
+       +--rw otn-step?   uint16
   augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
     +--:(otn)
        +--rw tpn?       uint16
@@ -371,6 +392,9 @@ module: ietf-otn-topology
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
+  augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity/tet:label-restrictions/tet:label-restriction/tet:label-step/tet:technology:
+    +--:(otn)
+       +--rw otn-step?   uint16
   augment /nw:networks/nw:network/nw:node/tet:te/tet:tunnel-termination-point/tet:local-link-connectivities/tet:local-link-connectivity/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
     +--:(otn)
        +--rw tpn?       uint16
@@ -424,6 +448,9 @@ module: ietf-otn-topology
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:te-link-attributes/tet:label-restrictions/tet:label-restriction/tet:label-step/tet:technology:
+    +--:(otn)
+       +--rw otn-step?   uint16
   augment /nw:networks/nw:network/nt:link/tet:te/tet:information-source-entry/tet:label-restrictions/tet:label-restriction:
     +--ro range-type?   identityref
     +--ro tsg?          identityref
@@ -442,6 +469,9 @@ module: ietf-otn-topology
           |  +--ro tpn?   uint16
           +--:(tributary-slot)
              +--ro ts?    uint16
+  augment /nw:networks/nw:network/nt:link/tet:te/tet:information-source-entry/tet:label-restrictions/tet:label-restriction/tet:label-step/tet:technology:
+    +--:(otn)
+       +--ro otn-step?   uint16
   augment /nw:networks/tet:te/tet:templates/tet:link-template/tet:te-link-attributes/tet:underlay/tet:primary-path/tet:path-element/tet:type/tet:label/tet:label-hop/tet:te-label/tet:technology:
     +--:(otn)
        +--rw tpn?       uint16
@@ -470,3 +500,6 @@ module: ietf-otn-topology
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
+  augment /nw:networks/tet:te/tet:templates/tet:link-template/tet:te-link-attributes/tet:label-restrictions/tet:label-restriction/tet:label-step/tet:technology:
+    +--:(otn)
+       +--rw otn-step?   uint16

--- a/YANG/ccamp/otn-topology/ietf-otn-topology.yang
+++ b/YANG/ccamp/otn-topology/ietf-otn-topology.yang
@@ -1,4 +1,3 @@
-
 module ietf-otn-topology {
   yang-version 1.1;
 
@@ -17,8 +16,8 @@ module ietf-otn-topology {
 
   import ietf-te-topology {
     prefix "tet";
-    reference 
-    "I-D.ietf-teas-yang-te-topo: YANG Data Model for 
+    reference
+    "I-D.ietf-teas-yang-te-topo: YANG Data Model for
     Traffic Engineering (TE) Topologies";
   }
 
@@ -65,23 +64,23 @@ module ietf-otn-topology {
   description
     "This module defines a protocol independent Layer 1/ODU topology
      data model.
-     
+
     Copyright (c) 2018 IETF Trust and the persons
- 	  identified as authors of the code.  All rights reserved.
+          identified as authors of the code.  All rights reserved.
 
-  	Redistribution and use in source and binary forms, with or
-  	without modification, is permitted pursuant to, and subject
-  	to the license terms contained in, the Simplified BSD License
-  	set forth in Section 4.c of the IETF Trust's Legal Provisions
-  	Relating to IETF Documents
-  	(https://trustee.ietf.org/license-info).";
+        Redistribution and use in source and binary forms, with or
+        without modification, is permitted pursuant to, and subject
+        to the license terms contained in, the Simplified BSD License
+        set forth in Section 4.c of the IETF Trust's Legal Provisions
+        Relating to IETF Documents
+        (https://trustee.ietf.org/license-info).";
 
-  revision 2018-08-23 {
+  revision 2018-12-05 {
     description
       "Initial Revision";
     reference
       "RFC XXXX: A YANG Data Model for Optical Transport Network Topology";
-    // RFC Ed.: replace XXXX with actual RFC number, update date 
+    // RFC Ed.: replace XXXX with actual RFC number, update date
     // information and remove this note
   }
 
@@ -137,7 +136,6 @@ module ietf-otn-topology {
  /*
   * Data nodes
   */
-
   augment "/nw:networks/nw:network/nw:network-types/"
         + "tet:te-topology" {
     container otn-topology {
@@ -186,7 +184,6 @@ module ietf-otn-topology {
       uses otn-types:otn-path-bandwidth;
     }
   }
-
   /* Augment bandwidth path constraints of connectivity-matrices */
   augment "/nw:networks/nw:network/nw:node/tet:te/"
         + "tet:te-node-attributes/tet:connectivity-matrices/"
@@ -526,6 +523,21 @@ module ietf-otn-topology {
     }
   }
 
+  /* Augment label restrictions step of connectivity-matrices */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:label-restrictions/tet:label-restriction/tet:label-step/"
+        + "tet:technology" {
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-label-step;
+    }
+  }
+  
   /* Augment label hop of underlay primary path of connectivity-matrices */
   augment "/nw:networks/nw:network/nw:node/tet:te/"
         + "tet:te-node-attributes/tet:connectivity-matrices/"
@@ -663,6 +675,23 @@ module ietf-otn-topology {
     }
   }
 
+  /* Augment ingress label restrictions step of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/tet:from/"
+        + "tet:label-restrictions/tet:label-restriction/tet:label-step/"
+        + "tet:technology" {
+    when "../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-label-step;
+    }
+  }
+
   /* Augment egress label restrictions of connectivity-matrix */
   augment "/nw:networks/nw:network/nw:node/tet:te/"
         + "tet:te-node-attributes/tet:connectivity-matrices/"
@@ -707,6 +736,23 @@ module ietf-otn-topology {
     description "OTN label.";
     case otn {
       uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment egress label restrictions step of connectivity-matrix */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:te-node-attributes/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/tet:to/"
+        + "tet:label-restrictions/tet:label-restriction/tet:label-step/"
+        + "tet:technology" {
+    when "../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-label-step;
     }
   }
 
@@ -846,6 +892,22 @@ module ietf-otn-topology {
     }
   }
 
+  /* Augment label restrictions step of connectivity-matrices information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/"
+        + "tet:connectivity-matrices/tet:label-restrictions/tet:label-restriction/"
+        + "tet:label-step/tet:technology" {
+    when "../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-label-step;
+    }
+  }
+
   /* Augment label hop of underlay primary path of connectivity-matrices information-source */
   augment "/nw:networks/nw:network/nw:node/tet:te/"
         + "tet:information-source-entry/tet:connectivity-matrices/"
@@ -980,6 +1042,23 @@ module ietf-otn-topology {
     }
   }
 
+  /* Augment ingress label restrictions step of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:from/tet:label-restrictions/tet:label-restriction/"
+        + "tet:label-step/tet:technology" {
+    when "../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-label-step;
+    }
+  }
+
   /* Augment egress label restrictions of connectivity-matrix information-source */
   augment "/nw:networks/nw:network/nw:node/tet:te/"
         + "tet:information-source-entry/tet:connectivity-matrices/"
@@ -1024,6 +1103,23 @@ module ietf-otn-topology {
     description "OTN label.";
     case otn {
       uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment egress label restrictions step of connectivity-matrix information-source */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:information-source-entry/tet:connectivity-matrices/"
+        + "tet:connectivity-matrix/"
+        + "tet:to/tet:label-restrictions/tet:label-restriction/"
+        + "tet:label-step/tet:technology" {
+    when "../../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-label-step;
     }
   }
 
@@ -1160,6 +1256,22 @@ module ietf-otn-topology {
     description "OTN label.";
     case otn {
       uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label restrictions step of local-link-connectivities */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:label-restrictions/tet:label-restriction/tet:label-step/"
+        + "tet:technology"{
+    when "../../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-label-step;
     }
   }
 
@@ -1302,6 +1414,24 @@ module ietf-otn-topology {
     description "OTN label.";
     case otn {
       uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label restrictions step of local-link-connectivity (LLC) */
+  augment "/nw:networks/nw:network/nw:node/tet:te/"
+        + "tet:tunnel-termination-point/"
+        + "tet:local-link-connectivities/"
+        + "tet:local-link-connectivity/"
+        + "tet:label-restrictions/tet:label-restriction/"
+        + "tet:label-step/tet:technology" {
+    when "../../../../../../../../"
+       + "nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-label-step;
     }
   }
 
@@ -1476,6 +1606,21 @@ module ietf-otn-topology {
     }
   }
 
+  /* Augment label restrictions step of TE link */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:te-link-attributes/"
+        + "tet:label-restrictions/tet:label-restriction/"
+        + "tet:label-step/tet:technology" {
+    when "../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-label-step;
+    }
+  }
+
   /* Augment label restrictions of TE link information-source */
   augment "/nw:networks/nw:network/nt:link/tet:te/"
         + "tet:information-source-entry/"
@@ -1514,6 +1659,21 @@ module ietf-otn-topology {
     description "OTN label.";
     case otn {
       uses otn-types:otn-link-label;
+    }
+  }
+
+  /* Augment label restrictions step of TE link information-source */
+  augment "/nw:networks/nw:network/nt:link/tet:te/"
+        + "tet:information-source-entry/"
+        + "tet:label-restrictions/tet:label-restriction/"
+        + "tet:label-step/tet:technology" {
+    when "../../../../../../nw:network-types/tet:te-topology/"
+       + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-label-step;
     }
   }
 
@@ -1599,5 +1759,22 @@ module ietf-otn-topology {
       uses otn-types:otn-link-label;
     }
   }
-}
 
+  /* Augment label restrictions step of TE link template */
+  augment "/nw:networks/tet:te/tet:templates/"
+        + "tet:link-template/tet:te-link-attributes/"
+        + "tet:label-restrictions/tet:label-restriction/"
+        + "tet:label-step/tet:technology" {
+/*
+    when "../../../../../../nw:network-types/tet:te-topology/"
+        + "otntopo:otn-topology" {
+      description "Augment OTN TE label";
+    }
+*/
+    description "OTN label.";
+    case otn {
+      uses otn-types:otn-label-step;
+    }
+  }
+  
+}

--- a/YANG/ccamp/otn-topology/ietf-otn-topology.yang
+++ b/YANG/ccamp/otn-topology/ietf-otn-topology.yang
@@ -24,8 +24,7 @@ module ietf-otn-topology {
   import ietf-otn-types {
     prefix "otn-types";
     reference
-         "I-D.ietf-teas-yang-te: A YANG Data Model for Traffic
-          Engineering Tunnels and Interfaces";
+         "I-D.ietf-ccamp-otn-tunnel-model: OTN Tunnel YANG Model";
   }
 
   organization
@@ -65,7 +64,7 @@ module ietf-otn-topology {
     "This module defines a protocol independent Layer 1/ODU topology
      data model.
 
-    Copyright (c) 2018 IETF Trust and the persons
+    Copyright (c) 2019 IETF Trust and the persons
           identified as authors of the code.  All rights reserved.
 
         Redistribution and use in source and binary forms, with or
@@ -75,7 +74,7 @@ module ietf-otn-topology {
         Relating to IETF Documents
         (https://trustee.ietf.org/license-info).";
 
-  revision 2018-12-05 {
+  revision 2019-02-25 {
     description
       "Initial Revision";
     reference

--- a/YANG/ccamp/otn-tunnel/ietf-otn-tunnel.tree
+++ b/YANG/ccamp/otn-tunnel/ietf-otn-tunnel.tree
@@ -1,8 +1,8 @@
 
 module: ietf-otn-tunnel
   augment /te:te/te:tunnels/te:tunnel:
-    +--rw src-client-signal?     identityref
-    +--rw dst-client-signal?     identityref
+    +--rw src-client-signal?   identityref
+    +--rw dst-client-signal?   identityref
   augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:te-bandwidth/te:technology:
     +--:(otn)
        +--rw odu-type?   identityref
@@ -28,72 +28,36 @@ module: ietf-otn-tunnel
        +--rw tpn?       uint16
        +--rw tsg?       identityref
        +--rw ts-list?   string
-  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-in-segment/te:forward/te:label-restrictions/te:label-restriction:
+  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-in-segment/te:label-restrictions/te:label-restriction:
     +--rw range-type?   identityref
     +--rw tsg?          identityref
     +--rw priority?     uint8
-  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-in-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
+  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-in-segment/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-in-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
+  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-in-segment/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-in-segment/te:reverse/te:label-restrictions/te:label-restriction:
+  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-out-segment/te:label-restrictions/te:label-restriction:
     +--rw range-type?   identityref
     +--rw tsg?          identityref
     +--rw priority?     uint8
-  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-in-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
+  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-out-segment/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-in-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-out-segment/te:forward/te:label-restrictions/te:label-restriction:
-    +--rw range-type?   identityref
-    +--rw tsg?          identityref
-    +--rw priority?     uint8
-  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-out-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-out-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-out-segment/te:reverse/te:label-restrictions/te:label-restriction:
-    +--rw range-type?   identityref
-    +--rw tsg?          identityref
-    +--rw priority?     uint8
-  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-out-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-out-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
+  augment /te:te/te:globals/te:named-path-constraints/te:named-path-constraint/te:path-out-segment/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
@@ -120,79 +84,43 @@ module: ietf-otn-tunnel
        +--rw tpn?       uint16
        +--rw tsg?       identityref
        +--rw ts-list?   string
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-in-segment/te:forward/te:label-restrictions/te:label-restriction:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-in-segment/te:label-restrictions/te:label-restriction:
     +--rw range-type?   identityref
     +--rw tsg?          identityref
     +--rw priority?     uint8
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-in-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-in-segment/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-in-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-in-segment/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-in-segment/te:reverse/te:label-restrictions/te:label-restriction:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-out-segment/te:label-restrictions/te:label-restriction:
     +--rw range-type?   identityref
     +--rw tsg?          identityref
     +--rw priority?     uint8
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-in-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-out-segment/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-in-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-out-segment/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-out-segment/te:forward/te:label-restrictions/te:label-restriction:
-    +--rw range-type?   identityref
-    +--rw tsg?          identityref
-    +--rw priority?     uint8
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-out-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-out-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-out-segment/te:reverse/te:label-restrictions/te:label-restriction:
-    +--rw range-type?   identityref
-    +--rw tsg?          identityref
-    +--rw priority?     uint8
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-out-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:path-out-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:state/te:path-properties/te:path-route-objects/te:path-computed-route-object/te:state/te:type/te:label/te:label-hop/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:state/te:computed-paths-properties/te:computed-path-properties/te:path-properties/te:path-route-objects/te:path-computed-route-object/te:state/te:type/te:label/te:label-hop/te:te-label/te:technology:
     +--:(otn)
        +--ro tpn?       uint16
        +--ro tsg?       identityref
@@ -227,79 +155,43 @@ module: ietf-otn-tunnel
        +--rw tpn?       uint16
        +--rw tsg?       identityref
        +--rw ts-list?   string
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-in-segment/te:forward/te:label-restrictions/te:label-restriction:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-in-segment/te:label-restrictions/te:label-restriction:
     +--rw range-type?   identityref
     +--rw tsg?          identityref
     +--rw priority?     uint8
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-in-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-in-segment/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-in-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-in-segment/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-in-segment/te:reverse/te:label-restrictions/te:label-restriction:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-out-segment/te:label-restrictions/te:label-restriction:
     +--rw range-type?   identityref
     +--rw tsg?          identityref
     +--rw priority?     uint8
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-in-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-out-segment/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-in-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-out-segment/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-out-segment/te:forward/te:label-restrictions/te:label-restriction:
-    +--rw range-type?   identityref
-    +--rw tsg?          identityref
-    +--rw priority?     uint8
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-out-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-out-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-out-segment/te:reverse/te:label-restrictions/te:label-restriction:
-    +--rw range-type?   identityref
-    +--rw tsg?          identityref
-    +--rw priority?     uint8
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-out-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:path-out-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:state/te:path-properties/te:path-route-objects/te:path-computed-route-object/te:state/te:type/te:label/te:label-hop/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-primary-paths/te:p2p-primary-path/te:p2p-reverse-primary-path/te:state/te:computed-paths-properties/te:computed-path-properties/te:path-properties/te:path-route-objects/te:path-computed-route-object/te:state/te:type/te:label/te:label-hop/te:te-label/te:technology:
     +--:(otn)
        +--ro tpn?       uint16
        +--ro tsg?       identityref
@@ -334,79 +226,43 @@ module: ietf-otn-tunnel
        +--rw tpn?       uint16
        +--rw tsg?       identityref
        +--rw ts-list?   string
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-in-segment/te:forward/te:label-restrictions/te:label-restriction:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-in-segment/te:label-restrictions/te:label-restriction:
     +--rw range-type?   identityref
     +--rw tsg?          identityref
     +--rw priority?     uint8
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-in-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-in-segment/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-in-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-in-segment/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-in-segment/te:reverse/te:label-restrictions/te:label-restriction:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-out-segment/te:label-restrictions/te:label-restriction:
     +--rw range-type?   identityref
     +--rw tsg?          identityref
     +--rw priority?     uint8
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-in-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-out-segment/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-in-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-out-segment/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
     +--:(otn)
        +--rw (otn-label-type)?
           +--:(tributary-port)
           |  +--rw tpn?   uint16
           +--:(tributary-slot)
              +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-out-segment/te:forward/te:label-restrictions/te:label-restriction:
-    +--rw range-type?   identityref
-    +--rw tsg?          identityref
-    +--rw priority?     uint8
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-out-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-out-segment/te:forward/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-out-segment/te:reverse/te:label-restrictions/te:label-restriction:
-    +--rw range-type?   identityref
-    +--rw tsg?          identityref
-    +--rw priority?     uint8
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-out-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-start/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:path-out-segment/te:reverse/te:label-restrictions/te:label-restriction/te:label-end/te:te-label/te:technology:
-    +--:(otn)
-       +--rw (otn-label-type)?
-          +--:(tributary-port)
-          |  +--rw tpn?   uint16
-          +--:(tributary-slot)
-             +--rw ts?    uint16
-  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:state/te:path-properties/te:path-route-objects/te:path-computed-route-object/te:state/te:type/te:label/te:label-hop/te:te-label/te:technology:
+  augment /te:te/te:tunnels/te:tunnel/te:p2p-secondary-paths/te:p2p-secondary-path/te:state/te:computed-paths-properties/te:computed-path-properties/te:path-properties/te:path-route-objects/te:path-computed-route-object/te:state/te:type/te:label/te:label-hop/te:te-label/te:technology:
     +--:(otn)
        +--ro tpn?       uint16
        +--ro tsg?       identityref
@@ -474,12 +330,12 @@ module: ietf-otn-tunnel
        |     |                    +---w te-label
        |     |                       +---w (technology)?
        |     |                       |  +--:(generic)
-       |     |                       |  |  +---w generic?   rt-types:generalized-label
+       |     |                       |  |  +---w generic?     rt-types:generalized-label
        |     |                       |  +--:(otn)
-       |     |                       |     +---w tpn?       uint16
-       |     |                       |     +---w tsg?       identityref
-       |     |                       |     +---w ts-list?   string
-       |     |                       +---w direction?       te-label-direction
+       |     |                       |     +---w tpn?         uint16
+       |     |                       |     +---w tsg?         identityref
+       |     |                       |     +---w ts-list?     string
+       |     |                       +---w direction?   te-label-direction
        |     +---w p2p-secondary-paths
        |     |  +---w p2p-secondary-path* [name]
        |     |     +---w name                      string
@@ -506,18 +362,14 @@ module: ietf-otn-tunnel
        |     |                    +---w te-label
        |     |                       +---w (technology)?
        |     |                       |  +--:(generic)
-       |     |                       |  |  +---w generic?   rt-types:generalized-label
+       |     |                       |  |  +---w generic?     rt-types:generalized-label
        |     |                       |  +--:(otn)
-       |     |                       |     +---w tpn?       uint16
-       |     |                       |     +---w tsg?       identityref
-       |     |                       |     +---w ts-list?   string
-       |     |                       +---w direction?       te-label-direction
+       |     |                       |     +---w tpn?         uint16
+       |     |                       |     +---w tsg?         identityref
+       |     |                       |     +---w ts-list?     string
+       |     |                       +---w direction?   te-label-direction
        |     +---w src-client-signal?     identityref
-       |     +---w src-tributary-slots
-       |     |  +---w values*   uint8
        |     +---w dst-client-signal?     identityref
-       |     +---w dst-tributary-slots
-       |        +---w values*   uint8
        +--ro output
           +--ro return-code?   enumeration
           +--ro result* [id]
@@ -548,12 +400,12 @@ module: ietf-otn-tunnel
              |                    +--ro te-label
              |                       +--ro (technology)?
              |                       |  +--:(generic)
-             |                       |  |  +--ro generic?   rt-types:generalized-label
+             |                       |  |  +--ro generic?     rt-types:generalized-label
              |                       |  +--:(otn)
-             |                       |     +--ro tpn?       uint16
-             |                       |     +--ro tsg?       identityref
-             |                       |     +--ro ts-list?   string
-             |                       +--ro direction?       te-label-direction
+             |                       |     +--ro tpn?         uint16
+             |                       |     +--ro tsg?         identityref
+             |                       |     +--ro ts-list?     string
+             |                       +--ro direction?   te-label-direction
              +--ro p2p-secondary-paths
                 +--ro p2p-secondary-path* [name]
                    +--ro name                      string
@@ -580,9 +432,9 @@ module: ietf-otn-tunnel
                                   +--ro te-label
                                      +--ro (technology)?
                                      |  +--:(generic)
-                                     |  |  +--ro generic?   rt-types:generalized-label
+                                     |  |  +--ro generic?     rt-types:generalized-label
                                      |  +--:(otn)
-                                     |     +--ro tpn?       uint16
-                                     |     +--ro tsg?       identityref
-                                     |     +--ro ts-list?   string
-                                     +--ro direction?       te-label-direction
+                                     |     +--ro tpn?         uint16
+                                     |     +--ro tsg?         identityref
+                                     |     +--ro ts-list?     string
+                                     +--ro direction?   te-label-direction

--- a/YANG/ccamp/otn-tunnel/ietf-otn-tunnel.yang
+++ b/YANG/ccamp/otn-tunnel/ietf-otn-tunnel.yang
@@ -6,21 +6,21 @@ module ietf-otn-tunnel {
 
   import ietf-te {
     prefix "te";
-    reference 
-    "I-D.ietf-teas-yang-te: A YANG Data Model for Traffic Engineering 
+    reference
+    "I-D.ietf-teas-yang-te: A YANG Data Model for Traffic Engineering
     Tunnels and Interfaces";
   }
 
   import ietf-otn-types {
     prefix "otn-types";
-    reference 
+    reference
     "module ietf-otn-types in this Document";
   }
 
   import ietf-te-types {
     prefix "te-types";
-    reference 
-    "I-D.ietf-teas-yang-te: A YANG Data Model for Traffic Engineering 
+    reference
+    "I-D.ietf-teas-yang-te: A YANG Data Model for Traffic Engineering
     Tunnels and Interfaces";
   }
 
@@ -64,23 +64,23 @@ module ietf-otn-tunnel {
 
   description
     "This module defines a model for OTN Tunnel Services.
-    
+
     Copyright (c) 2018 IETF Trust and the persons
- 	  identified as authors of the code.  All rights reserved.
+          identified as authors of the code.  All rights reserved.
 
-  	Redistribution and use in source and binary forms, with or
-  	without modification, is permitted pursuant to, and subject
-  	to the license terms contained in, the Simplified BSD License
-  	set forth in Section 4.c of the IETF Trust's Legal Provisions
-  	Relating to IETF Documents
-  	(https://trustee.ietf.org/license-info).";
+        Redistribution and use in source and binary forms, with or
+        without modification, is permitted pursuant to, and subject
+        to the license terms contained in, the Simplified BSD License
+        set forth in Section 4.c of the IETF Trust's Legal Provisions
+        Relating to IETF Documents
+        (https://trustee.ietf.org/license-info).";
 
-  revision "2018-08-23" {
+  revision "2018-12-05" {
     description
       "Initial Revision";
     reference
       "RFC XXXX: OTN Tunnel YANG Model";
-    // RFC Ed.: replace XXXX with actual RFC number, update date 
+    // RFC Ed.: replace XXXX with actual RFC number, update date
     // information and remove this note
   }
 
@@ -200,19 +200,19 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions for the forwarding direction of path-in-segment of named-path-constraints */
+  /* Augment label restrictions for the path-in-segment of named-path-constraints */
   augment "/te:te/te:globals/te:named-path-constraints/"
         + "te:named-path-constraint/te:path-in-segment/"
-        + "te:forward/te:label-restrictions/"
+        + "te:label-restrictions/"
         + "te:label-restriction" {
     description "OTN label.";
     uses otn-types:otn-label-restriction;
   }
 
-  /* Augment label restrictions start for the forwarding direction of path-in-segment of named-path-constraints */
+  /* Augment label restrictions start for the path-in-segment of named-path-constraints */
   augment "/te:te/te:globals/te:named-path-constraints/"
         + "te:named-path-constraint/te:path-in-segment/"
-        + "te:forward/te:label-restrictions/"
+        + "te:label-restrictions/"
         + "te:label-restriction/te:label-start/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -221,10 +221,10 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions end for the forwarding direction of path-in-segment of named-path-constraints */
+  /* Augment label restrictions end for the path-in-segment of named-path-constraints */
   augment "/te:te/te:globals/te:named-path-constraints/"
         + "te:named-path-constraint/te:path-in-segment/"
-        + "te:forward/te:label-restrictions/"
+        + "te:label-restrictions/"
         + "te:label-restriction/te:label-end/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -233,19 +233,18 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions for the reverse direction of path-in-segment of named-path-constraints */
+  /* Augment label restrictions for the path-out-segment of named-path-constraints */
   augment "/te:te/te:globals/te:named-path-constraints/"
-        + "te:named-path-constraint/te:path-in-segment/"
-        + "te:reverse/te:label-restrictions/"
+        + "te:named-path-constraint/te:path-out-segment/"
+        + "te:label-restrictions/"
         + "te:label-restriction" {
     description "OTN label.";
     uses otn-types:otn-label-restriction;
   }
-
-  /* Augment label restrictions start for the reverse direction of path-in-segment of named-path-constraints */
+  /* Augment label restrictions start for the path-out-segment of named-path-constraints */
   augment "/te:te/te:globals/te:named-path-constraints/"
-        + "te:named-path-constraint/te:path-in-segment/"
-        + "te:reverse/te:label-restrictions/"
+        + "te:named-path-constraint/te:path-out-segment/"
+        + "te:label-restrictions/"
         + "te:label-restriction/te:label-start/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -254,77 +253,10 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions end for the reverse direction of path-in-segment of named-path-constraints */
-  augment "/te:te/te:globals/te:named-path-constraints/"
-        + "te:named-path-constraint/te:path-in-segment/"
-        + "te:reverse/te:label-restrictions/"
-        + "te:label-restriction/te:label-end/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions for the forwarding direction of path-out-segment of named-path-constraints */
+  /* Augment label restrictions end for the path-out-segment of named-path-constraints */
   augment "/te:te/te:globals/te:named-path-constraints/"
         + "te:named-path-constraint/te:path-out-segment/"
-
-        + "te:forward/te:label-restrictions/"
-        + "te:label-restriction" {
-    description "OTN label.";
-    uses otn-types:otn-label-restriction;
-  }
-  /* Augment label restrictions start for the forwarding direction of path-out-segment of named-path-constraints */
-  augment "/te:te/te:globals/te:named-path-constraints/"
-        + "te:named-path-constraint/te:path-out-segment/"
-        + "te:forward/te:label-restrictions/"
-        + "te:label-restriction/te:label-start/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions end for the forwarding direction of path-out-segment of named-path-constraints */
-  augment "/te:te/te:globals/te:named-path-constraints/"
-        + "te:named-path-constraint/te:path-out-segment/"
-        + "te:forward/te:label-restrictions/"
-        + "te:label-restriction/te:label-end/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions for the reverse direction of path-out-segment of named-path-constraints */
-  augment "/te:te/te:globals/te:named-path-constraints/"
-        + "te:named-path-constraint/te:path-out-segment/"
-        + "te:reverse/te:label-restrictions/"
-        + "te:label-restriction" {
-    description "OTN label.";
-    uses otn-types:otn-label-restriction;
-  }
-
-  /* Augment label restrictions start for the reverse direction of path-out-segment of named-path-constraints */
-  augment "/te:te/te:globals/te:named-path-constraints/"
-        + "te:named-path-constraint/te:path-out-segment/"
-        + "te:reverse/te:label-restrictions/"
-        + "te:label-restriction/te:label-start/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-
-  }
-
-  /* Augment label restrictions end for the reverse direction of path-out-segment of named-path-constraints */
-  augment "/te:te/te:globals/te:named-path-constraints/"
-        + "te:named-path-constraint/te:path-out-segment/"
-        + "te:reverse/te:label-restrictions/"
+        + "te:label-restrictions/"
         + "te:label-restriction/te:label-end/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -345,7 +277,6 @@ module ietf-otn-tunnel {
       uses otn-types:otn-path-label;
     }
   }
-
   /* Augment label hop of route-include of primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
@@ -384,19 +315,19 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions for the forwarding direction of path-in-segment of primary path */
+  /* Augment label restrictions for the path-in-segment of primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:path-in-segment/te:forward/te:label-restrictions/"
+        + "te:path-in-segment/te:label-restrictions/"
         + "te:label-restriction" {
     description "OTN label.";
     uses otn-types:otn-label-restriction;
   }
 
-  /* Augment label restrictions start for the forwarding direction of path-in-segment of primary path */
+  /* Augment label restrictions start for the path-in-segment of primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:path-in-segment/te:forward/te:label-restrictions/"
+        + "te:path-in-segment/te:label-restrictions/"
         + "te:label-restriction/te:label-start/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -405,10 +336,10 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions end for the forwarding direction of path-in-segment of primary path */
+  /* Augment label restrictions end for the path-in-segment of primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:path-in-segment/te:forward/te:label-restrictions/"
+        + "te:path-in-segment/te:label-restrictions/"
         + "te:label-restriction/te:label-end/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -417,52 +348,19 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions for the reverse direction of path-in-segment of primary path */
+  /* Augment label restrictions for the path-out-segment of primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:path-in-segment/te:reverse/te:label-restrictions/"
+        + "te:path-out-segment/te:label-restrictions/"
         + "te:label-restriction" {
     description "OTN label.";
     uses otn-types:otn-label-restriction;
   }
 
-  /* Augment label restrictions start for the reverse direction of path-in-segment of primary path */
+  /* Augment label restrictions start for the path-out-segment of primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:path-in-segment/te:reverse/te:label-restrictions/"
-        + "te:label-restriction/te:label-start/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions end for the reverse direction of path-in-segment of primary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:path-in-segment/te:reverse/te:label-restrictions/"
-        + "te:label-restriction/te:label-end/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions for the forwarding direction of path-out-segment of primary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:path-out-segment/te:forward/te:label-restrictions/"
-        + "te:label-restriction" {
-    description "OTN label.";
-    uses otn-types:otn-label-restriction;
-  }
-
-  /* Augment label restrictions start for the forwarding direction of path-out-segment of primary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:path-out-segment/te:forward/te:label-restrictions/"
+        + "te:path-out-segment/te:label-restrictions/"
         + "te:label-restriction/te:label-start/"
         + "te:te-label/te:technology" {
 
@@ -472,56 +370,23 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions end for the forwarding direction of path-out-segment of primary path */
+  /* Augment label restrictions end for the path-out-segment of primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:path-out-segment/te:forward/te:label-restrictions/"
+        + "te:path-out-segment/te:label-restrictions/"
         + "te:label-restriction/te:label-end/"
         + "te:te-label/te:technology" {
     description "OTN label.";
     case otn {
       uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions for the reverse direction of path-out-segment of primary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:path-out-segment/te:reverse/te:label-restrictions/"
-        + "te:label-restriction" {
-    description "OTN label.";
-    uses otn-types:otn-label-restriction;
-  }
-
-  /* Augment label restrictions start for the reverse direction of path-out-segment of primary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:path-out-segment/te:reverse/te:label-restrictions/"
-        + "te:label-restriction/te:label-start/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions end for the reverse direction of path-out-segment of primary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:path-out-segment/te:reverse/te:label-restrictions/"
-        + "te:label-restriction/te:label-end/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-
     }
   }
 
   /* Augment label hop of path-route of primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:state/te:path-properties/"
+        + "te:state/te:computed-paths-properties/"
+		+ "te:computed-path-properties/te:path-properties/"
         + "te:path-route-objects/te:path-computed-route-object/"
         + "te:state/te:type/te:label/"
         + "te:label-hop/te:te-label/te:technology" {
@@ -613,21 +478,21 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions for the forwarding direction of path-in-segment of reverse primary path */
+  /* Augment label restrictions for the path-in-segment of reverse primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
         + "te:p2p-reverse-primary-path/"
-        + "te:path-in-segment/te:forward/te:label-restrictions/"
+        + "te:path-in-segment/te:label-restrictions/"
         + "te:label-restriction" {
     description "OTN label.";
     uses otn-types:otn-label-restriction;
   }
 
-  /* Augment label restrictions start for the forwarding direction of path-in-segment of reverse primary path */
+  /* Augment label restrictions start for the path-in-segment of reverse primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
         + "te:p2p-reverse-primary-path/"
-        + "te:path-in-segment/te:forward/te:label-restrictions/"
+        + "te:path-in-segment/te:label-restrictions/"
         + "te:label-restriction/te:label-start/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -636,11 +501,11 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions end for the forwarding direction of path-in-segment of reverse primary path */
+  /* Augment label restrictions end for the path-in-segment of reverse primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
         + "te:p2p-reverse-primary-path/"
-        + "te:path-in-segment/te:forward/te:label-restrictions/"
+        + "te:path-in-segment/te:label-restrictions/"
         + "te:label-restriction/te:label-end/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -649,22 +514,21 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions for the reverse direction of path-in-segment of reverse primary path */
+  /* Augment label restrictions for the path-out-segment of reverse primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
         + "te:p2p-reverse-primary-path/"
-        + "te:path-in-segment/te:reverse/te:label-restrictions/"
+        + "te:path-out-segment/te:label-restrictions/"
         + "te:label-restriction" {
     description "OTN label.";
     uses otn-types:otn-label-restriction;
   }
 
-  /* Augment label restrictions start for the reverse direction of path-in-segment of reverse primary path */
+  /* Augment label restrictions start for the path-out-segment of reverse primary path */
   augment "/te:te/te:tunnels/te:tunnel/"
-
         + "te:p2p-primary-paths/te:p2p-primary-path/"
         + "te:p2p-reverse-primary-path/"
-        + "te:path-in-segment/te:reverse/te:label-restrictions/"
+        + "te:path-out-segment/te:label-restrictions/"
         + "te:label-restriction/te:label-start/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -673,84 +537,12 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions end for the reverse direction of path-in-segment of reverse primary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:p2p-reverse-primary-path/"
-        + "te:path-in-segment/te:reverse/te:label-restrictions/"
-        + "te:label-restriction/te:label-end/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions for the forwarding direction of path-out-segment of reverse primary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:p2p-reverse-primary-path/"
-        + "te:path-out-segment/te:forward/te:label-restrictions/"
-        + "te:label-restriction" {
-    description "OTN label.";
-    uses otn-types:otn-label-restriction;
-  }
-
-  /* Augment label restrictions start for the forwarding direction of path-out-segment of reverse primary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:p2p-reverse-primary-path/"
-        + "te:path-out-segment/te:forward/te:label-restrictions/"
-        + "te:label-restriction/te:label-start/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions end for the forwarding direction of path-out-segment of reverse primary path */
+  /* Augment label restrictions end for the path-out-segment of reverse primary path */
 
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
         + "te:p2p-reverse-primary-path/"
-        + "te:path-out-segment/te:forward/te:label-restrictions/"
-        + "te:label-restriction/te:label-end/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions for the reverse direction of path-out-segment of reverse primary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:p2p-reverse-primary-path/"
-        + "te:path-out-segment/te:reverse/te:label-restrictions/"
-        + "te:label-restriction" {
-    description "OTN label.";
-    uses otn-types:otn-label-restriction;
-  }
-
-  /* Augment label restrictions start for the reverse direction of path-out-segment of reverse primary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:p2p-reverse-primary-path/"
-        + "te:path-out-segment/te:reverse/te:label-restrictions/"
-        + "te:label-restriction/te:label-start/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions end for the reverse direction of path-out-segment of reverse primary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-primary-paths/te:p2p-primary-path/"
-        + "te:p2p-reverse-primary-path/"
-        + "te:path-out-segment/te:reverse/te:label-restrictions/"
+        + "te:path-out-segment/te:label-restrictions/"
         + "te:label-restriction/te:label-end/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -763,7 +555,8 @@ module ietf-otn-tunnel {
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
         + "te:p2p-reverse-primary-path/"
-        + "te:state/te:path-properties/"
+        + "te:state/te:computed-paths-properties/"
+		+ "te:computed-path-properties/te:path-properties/"
         + "te:path-route-objects/te:path-computed-route-object/"
         + "te:state/te:type/te:label/"
         + "te:label-hop/te:te-label/te:technology" {
@@ -826,7 +619,6 @@ module ietf-otn-tunnel {
       uses otn-types:otn-path-label;
     }
   }
-
   /* Augment label hop of route-object-exclude-always of secondary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-secondary-paths/te:p2p-secondary-path/"
@@ -851,20 +643,20 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions for the forwarding direction of path-in-segment of secondary path */
+  /* Augment label restrictions for the path-in-segment of secondary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-        + "te:path-in-segment/te:forward/te:label-restrictions/"
+        + "te:path-in-segment/te:label-restrictions/"
         + "te:label-restriction" {
 
     description "OTN label.";
     uses otn-types:otn-label-restriction;
   }
 
-  /* Augment label restrictions start for the forwarding direction of path-in-segment of secondary path */
+  /* Augment label restrictions start for the path-in-segment of secondary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-        + "te:path-in-segment/te:forward/te:label-restrictions/"
+        + "te:path-in-segment/te:label-restrictions/"
         + "te:label-restriction/te:label-start/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -873,10 +665,10 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions end for the forwarding direction of path-in-segment of secondary path */
+  /* Augment label restrictions end for the path-in-segment of secondary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-        + "te:path-in-segment/te:forward/te:label-restrictions/"
+        + "te:path-in-segment/te:label-restrictions/"
         + "te:label-restriction/te:label-end/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -885,19 +677,19 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions for the reverse direction of path-in-segment of secondary path */
+  /* Augment label restrictions for the path-out-segment of secondary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-        + "te:path-in-segment/te:reverse/te:label-restrictions/"
+        + "te:path-out-segment/te:label-restrictions/"
         + "te:label-restriction" {
     description "OTN label.";
     uses otn-types:otn-label-restriction;
   }
 
-  /* Augment label restrictions start for the reverse direction of path-in-segment of secondary path */
+  /* Augment label restrictions start for the path-out-segment of secondary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-        + "te:path-in-segment/te:reverse/te:label-restrictions/"
+        + "te:path-out-segment/te:label-restrictions/"
         + "te:label-restriction/te:label-start/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -906,77 +698,10 @@ module ietf-otn-tunnel {
     }
   }
 
-  /* Augment label restrictions end for the reverse direction of path-in-segment of secondary path */
+  /* Augment label restrictions end for the path-out-segment of secondary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-        + "te:path-in-segment/te:reverse/te:label-restrictions/"
-        + "te:label-restriction/te:label-end/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions for the forwarding direction of path-out-segment of secondary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-        + "te:path-out-segment/te:forward/te:label-restrictions/"
-        + "te:label-restriction" {
-    description "OTN label.";
-    uses otn-types:otn-label-restriction;
-  }
-
-  /* Augment label restrictions start for the forwarding direction of path-out-segment of secondary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-        + "te:path-out-segment/te:forward/te:label-restrictions/"
-        + "te:label-restriction/te:label-start/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions end for the forwarding direction of path-out-segment of secondary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-        + "te:path-out-segment/te:forward/te:label-restrictions/"
-        + "te:label-restriction/te:label-end/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions for the reverse direction of path-out-segment of secondary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-
-        + "te:path-out-segment/te:reverse/te:label-restrictions/"
-        + "te:label-restriction" {
-    description "OTN label.";
-    uses otn-types:otn-label-restriction;
-  }
-
-  /* Augment label restrictions start for the reverse direction of path-out-segment of secondary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-        + "te:path-out-segment/te:reverse/te:label-restrictions/"
-        + "te:label-restriction/te:label-start/"
-        + "te:te-label/te:technology" {
-    description "OTN label.";
-    case otn {
-      uses otn-types:otn-link-label;
-    }
-  }
-
-  /* Augment label restrictions end for the reverse direction of path-out-segment of secondary path */
-  augment "/te:te/te:tunnels/te:tunnel/"
-        + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-        + "te:path-out-segment/te:reverse/te:label-restrictions/"
+        + "te:path-out-segment/te:label-restrictions/"
         + "te:label-restriction/te:label-end/"
         + "te:te-label/te:technology" {
     description "OTN label.";
@@ -988,7 +713,9 @@ module ietf-otn-tunnel {
   /* Augment label hop of path-route of secondary path */
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-secondary-paths/te:p2p-secondary-path/"
-        + "te:state/te:path-properties/te:path-route-objects/"
+        + "te:state/te:computed-paths-properties/"
+		+ "te:computed-path-properties/te:path-properties/"
+		+ "te:path-route-objects/"
         + "te:path-computed-route-object/te:state/te:type/te:label/"
         + "te:label-hop/te:te-label/te:technology" {
     description "OTN label.";
@@ -1066,6 +793,10 @@ module ietf-otn-tunnel {
           }
           description "An explicit-route hop action.";
         }
+		leaf index {
+		  type uint32;
+		  description "ERO subobject index";
+		}
         uses te-types:explicit-route-hop {
                   augment "type/label/label-hop/te-label/technology" {
                     description "OTN label.";
@@ -1092,7 +823,7 @@ module ietf-otn-tunnel {
         }
         leaf type {
           type identityref {
-            base te-types:tunnel-type;
+            base te-types:te-tunnel-type;
           }
           description "TE tunnel type.";
         }

--- a/YANG/ccamp/otn-tunnel/ietf-otn-tunnel.yang
+++ b/YANG/ccamp/otn-tunnel/ietf-otn-tunnel.yang
@@ -75,7 +75,7 @@ module ietf-otn-tunnel {
         Relating to IETF Documents
         (https://trustee.ietf.org/license-info).";
 
-  revision "2018-12-05" {
+  revision "2019-01-15" {
     description
       "Initial Revision";
     reference
@@ -386,7 +386,7 @@ module ietf-otn-tunnel {
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-primary-paths/te:p2p-primary-path/"
         + "te:state/te:computed-paths-properties/"
-		+ "te:computed-path-properties/te:path-properties/"
+        + "te:computed-path-properties/te:path-properties/"
         + "te:path-route-objects/te:path-computed-route-object/"
         + "te:state/te:type/te:label/"
         + "te:label-hop/te:te-label/te:technology" {
@@ -556,7 +556,7 @@ module ietf-otn-tunnel {
         + "te:p2p-primary-paths/te:p2p-primary-path/"
         + "te:p2p-reverse-primary-path/"
         + "te:state/te:computed-paths-properties/"
-		+ "te:computed-path-properties/te:path-properties/"
+        + "te:computed-path-properties/te:path-properties/"
         + "te:path-route-objects/te:path-computed-route-object/"
         + "te:state/te:type/te:label/"
         + "te:label-hop/te:te-label/te:technology" {
@@ -714,8 +714,8 @@ module ietf-otn-tunnel {
   augment "/te:te/te:tunnels/te:tunnel/"
         + "te:p2p-secondary-paths/te:p2p-secondary-path/"
         + "te:state/te:computed-paths-properties/"
-		+ "te:computed-path-properties/te:path-properties/"
-		+ "te:path-route-objects/"
+        + "te:computed-path-properties/te:path-properties/"
+        + "te:path-route-objects/"
         + "te:path-computed-route-object/te:state/te:type/te:label/"
         + "te:label-hop/te:te-label/te:technology" {
     description "OTN label.";
@@ -793,10 +793,10 @@ module ietf-otn-tunnel {
           }
           description "An explicit-route hop action.";
         }
-		leaf index {
-		  type uint32;
-		  description "ERO subobject index";
-		}
+        leaf index {
+          type uint32;
+          description "ERO subobject index";
+        }
         uses te-types:explicit-route-hop {
                   augment "type/label/label-hop/te-label/technology" {
                     description "OTN label.";

--- a/YANG/ccamp/otn-tunnel/ietf-otn-types.yang
+++ b/YANG/ccamp/otn-tunnel/ietf-otn-types.yang
@@ -38,7 +38,7 @@ module ietf-otn-types {
   description
     "This module defines OTN types.";
 
-  revision "2018-12-05" {
+  revision "2019-01-15" {
     description
       "Initial Revision";
     reference
@@ -418,21 +418,39 @@ otn-topology/tunnel also need change */
                    of Evolving G.709 Optical Transport Networks";
     }
   }
-
   grouping otn-label-step {
     description "Label step for OTN";
-    leaf otn-step {
-      type uint16 {
-        range "1..4095";
-      }
-	  default 1;
+    choice otn-label-type {
       description
-        "Label step which represent possible increments for 
-		 tributary port or tributary slot.";
-      reference
-        "RFC7139: GMPLS Signaling Extensions for Control of Evolving
-         G.709 Optical Transport Networks.";
+        "OTN label range type, either TPN range or TS range";
+      case tributary-port {
+        leaf tpn-step {
+          type uint16 {
+            range "1..4095";
+          }
+          default 1;
+          description
+            "Label step which represents possible increments for 
+             Tributary Port Number.";
+          reference
+            "RFC7139: GMPLS Signaling Extensions for Control of Evolving
+             G.709 Optical Transport Networks.";
+        }
+      }
+      case tributary-slot {
+        leaf ts {
+          type uint16 {
+            range "1..4095";
+          }
+          default 1;
+          description
+            "Label step which represents possible increments for 
+             Tributary Slot Number.";
+          reference
+            "RFC7139: GMPLS Signaling Extensions for Control of Evolving
+             G.709 Optical Transport Networks.";
+        }
+      }
     }
   }
-  
 }

--- a/YANG/ccamp/otn-tunnel/ietf-otn-types.yang
+++ b/YANG/ccamp/otn-tunnel/ietf-otn-types.yang
@@ -38,12 +38,12 @@ module ietf-otn-types {
   description
     "This module defines OTN types.";
 
-  revision "2018-08-23" {
+  revision "2018-12-05" {
     description
       "Initial Revision";
     reference
       "RFC XXXX: OTN Tunnel YANG Model";
-    // RFC Ed.: replace XXXX with actual RFC number, update date 
+    // RFC Ed.: replace XXXX with actual RFC number, update date
     // information and remove this note
   }
 
@@ -71,7 +71,6 @@ module ietf-otn-types {
     description
       "Base identity for protocol framing used by tributary signals";
   }
-
 
   identity ODU0 {
     base odu-type;
@@ -164,7 +163,7 @@ module ietf-otn-types {
       "Base identity from which specific client signals for the
        tunnel are derived";
   }
-  
+
   identity ETH-1Gb {
     base client-signal;
     description
@@ -248,13 +247,13 @@ module ietf-otn-types {
     description
       "Client signal type of Fibre Channel FC-800";
   }
-  
+
   identity FC-1200 {
     base client-signal;
     description
       "Client signal type of Fibre Channel FC-1200";
   }
-  
+
   identity FC-1600 {
     base client-signal;
     description
@@ -266,7 +265,7 @@ module ietf-otn-types {
     description
       "Client signal type of Fibre Channel FC-3200";
   }
-  
+
   identity FICON-4G {
     base client-signal;
     description
@@ -282,7 +281,7 @@ module ietf-otn-types {
   identity otn-label-range-type {
     description
       "Base identity from which specific OTN label
-	   range types derived";
+           range types derived";
   }
 
   identity label-range-trib-slot {
@@ -296,7 +295,7 @@ module ietf-otn-types {
     description
       "Defines a range of OTN tributary ports";
   }
-  
+
   grouping otn-link-bandwidth {
     description "link bandwidth attributes for OTN";
     list odulist {
@@ -317,7 +316,7 @@ module ietf-otn-types {
   }
 
   grouping otn-path-bandwidth {
-  	description "path bandwidth attributes for OTN";
+        description "path bandwidth attributes for OTN";
     leaf odu-type {
       type identityref {
         base otn-types:odu-type;
@@ -327,7 +326,7 @@ module ietf-otn-types {
   }
 
   grouping otn-label-restriction {
-  	description "label restriction information for OTN";
+        description "label restriction information for OTN";
     leaf range-type {
       type identityref {
         base otn-types:otn-label-range-type;
@@ -342,14 +341,14 @@ module ietf-otn-types {
       reference
         "G.709/Y.1331, February 2016: Interfaces for the
          Optical Transport Network (OTN)";
-    } 
+    }
     leaf priority {
       type uint8;
       description "priority.";
     }
   }
- 
-/* Note: Suggest to be changed as otn-label-range; 
+
+/* Note: Suggest to be changed as otn-label-range;
 otn-topology/tunnel also need change */
   grouping otn-link-label {
     description "link label information for OTN, for label-start/end";
@@ -383,7 +382,7 @@ otn-topology/tunnel also need change */
     }
   }
 
-/* Note: Suggest to be changed as otn-label; 
+/* Note: Suggest to be changed as otn-label;
 otn-topology/tunnel also need change */
   grouping otn-path-label {
     description "label information for OTN, for label-hop";
@@ -419,4 +418,21 @@ otn-topology/tunnel also need change */
                    of Evolving G.709 Optical Transport Networks";
     }
   }
+
+  grouping otn-label-step {
+    description "Label step for OTN";
+    leaf otn-step {
+      type uint16 {
+        range "1..4095";
+      }
+	  default 1;
+      description
+        "Label step which represent possible increments for 
+		 tributary port or tributary slot.";
+      reference
+        "RFC7139: GMPLS Signaling Extensions for Control of Evolving
+         G.709 Optical Transport Networks.";
+    }
+  }
+  
 }


### PR DESCRIPTION
Proposed changes (from Aihua) to align the OTN models with ietf-te-types@2018-10-08.yang (https://tools.ietf.org/html/draft-ietf-teas-yang-te-types-01):

- definition of otn-label-step
- no longer separation of forward and reverse label restriction containers
- different path used to report computed-path-properties
