### PR TITLE
PM model for ccamp-interim

### DIFF
--- a/YANG/ccamp/client-pm/ietf-eth-service-pm.tree
+++ b/YANG/ccamp/client-pm/ietf-eth-service-pm.tree
@@ -1,13 +1,20 @@
 module: ietf-eth-service-pm
   +--rw performance-monitoring
      +--rw service-pm* [service-name]
-        +--rw service-name          leafref
-        +--rw pm-enable?            boolean
-        +--rw latency-monitoring
-        |  +--rw latency-measure-enable?   boolean
+        +--rw service-name        leafref
+        +--rw pm-enable?          boolean
+        +--rw vlan-id?            etht-types:vlanid
         +--ro service-pm-state
+           +--ro performance-data* [parameter-name]
+           |  +--ro parameter-name     identityref
+           |  +--ro parameter-value* [value]
+           |     +--ro value
+           |     |       ethsvc-pm:performance-parameter
+           |     +--ro value-description?   string
+           +--ro monitor-state?         identityref
            +--ro start-time?            yang:date-and-time
            +--ro last-update-time?      yang:date-and-time
-           +--ro latency?               uint32
            +--ro error-message?         string
            +--ro service-oper-status?   identityref
+           +--ro alarm
+              +--ro status?   identityref

--- a/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
+++ b/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
@@ -71,7 +71,7 @@ module ietf-eth-service-pm {
         "To represent the type of value. ";
     }
 	
-  identity performance-type {
+  identity performance-parameter-type {
     description
       "Base type of the performance parameter being monitored. ";
   }

--- a/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
+++ b/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
@@ -38,7 +38,7 @@ module ietf-eth-service-pm {
      services. The model fully conforms to the Network Management 
      Datastore Architecture (NMDA).
     
-     Copyright (c) 2019 IETF Trust and the persons
+     Copyright (c) 2020 IETF Trust and the persons
      identified as authors of the code.  All rights reserved.
 
      Redistribution and use in source and binary forms, with or
@@ -50,13 +50,92 @@ module ietf-eth-service-pm {
      This version of this YANG module is part of RFC XXXX; see
      the RFC itself for full legal notices.";
   
-  revision 2019-11-04 {
+  revision 2020-05-07 {
     description
       "Initial version";
     reference
       "ADD REFERENCE HERE";
   }
 
+  typedef performance-parameter
+    {
+      type union {
+        type uint32;
+		type uint64;
+		type decimal64 {
+          fraction-digits 6;
+        }
+		type string; 
+      }
+      description
+        "To represent the type of value. ";
+    }
+	
+  identity performance-type {
+    description
+      "Base type of performance monitoring. ";
+  }
+
+  identity latency {
+    base performance-type;
+    description
+      "Latency measurement for performance monitoring. ";
+  }
+
+  identity bit-error-rate {
+    base performance-type;
+    description
+      "Bit Error Rate (BER) measurement for performance monitoring.";
+  }
+  
+  identity packet-loss {
+    base performance-type;
+    description
+      "Packet loss measurement for performance monitoring. ";
+  }
+  
+  identity bandwidth {
+    base performance-type;
+    description
+      "Bandwidth measurement for performance monitoring. ";
+  }
+  
+  identity alarm-status {
+    description "indicates whether there is alarm or not";
+  }
+
+  identity alarm {
+    base alarm-status;
+	description "There is one or multiple alarms from the monitor. ";
+  }
+
+  identity no-alarm {
+    base alarm-status;
+	description "There is no alarms from the monitor. ";
+  }
+  
+  identity monitoring-state {
+    description 
+	  "The state of performance monitoring. ";
+  }
+
+  identity monitoring {
+    base monitoring-state;
+	description "The Ethernet client signal is under monitoring. ";
+  }
+
+  identity monitor-finished {
+    base monitoring-state;
+	description 
+	  "The monitoring of Ethernet client signal is finished. ";
+  }
+
+  identity monitor-failed {
+    base monitoring-state;
+	description 
+	  "The monitoring of Ethernet client signal is failed. ";
+  }
+  
   container performance-monitoring {
     description 
       "This part is for performance monitoring. ";
@@ -77,22 +156,30 @@ module ietf-eth-service-pm {
           "Indicate whether the performance monitoring 
           is enable or not.";
       }
-      
-      container latency-monitoring {
-        description 
-          "To monitor the latency of service.";
-        leaf latency-measure-enable {
-          type boolean;
-          description
-            "Indicate whether the latency measurement 
-            is enable or not.";
-        }
+	  
+	  leaf vlan-id {
+        type etht-types:vlanid;
+        description
+          "The customer VLAN Identifier of the Ethernet Client to be monitored.";
       }
       
       container service-pm-state {
         config false;
         description 
-          "The state of service performance monitoring.";
+          "The state of service performance monitoring.";		  
+		
+		list performance-data{
+	      key parameter-name; 
+	      description "The list of performance under monitor.";
+	      uses service-performance-monitor-set;
+	    }
+		
+		leaf monitor-state {
+		  type identityref {
+		    base ethsvc-pm:monitoring-state;
+		  }
+		}
+		
         leaf start-time {
           type yang:date-and-time;
           description 
@@ -103,13 +190,6 @@ module ietf-eth-service-pm {
           type yang:date-and-time;
           description 
             "The time stamp when the service is last updated.";
-        }
-        
-        leaf latency {
-          type uint32;
-          units microsecond;
-          description 
-            "The latency of service.";
         }
         
         leaf error-message {
@@ -125,7 +205,43 @@ module ietf-eth-service-pm {
           description 
             "The operational status of the services.";
         }
+		container alarm {
+		  leaf status {
+		    type identityref {
+		      base ethsvc-pm:alarm-status;
+		    }
+		  }
+		}
       }
     }
+  }
+  
+  grouping service-performance-monitor-set{
+    description "the set of parameter name, value and description.";
+    leaf parameter-name{
+	  type identityref {
+	    base performance-type;
+	  }
+	  description 
+	    "The name of parameters to be monitored. 
+		For example, latency, Bit Error Rate, Bandwidth and so on.";
+	}
+	list parameter-value {
+	  key value; 
+	  description 
+	    "The table of values of the performance and 
+		their descriptions.";
+	  leaf value {
+	    mandatory true;
+		type ethsvc-pm:performance-parameter; 
+		description 
+		  "The value of the parameter. ";
+	  }
+	  leaf value-description{
+	    type string;
+		description 
+		  "The description of previous value. ";
+	  }
+	}
   }
 }

--- a/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
+++ b/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
@@ -223,8 +223,8 @@ module ietf-eth-service-pm {
 	    base performance-type;
 	  }
 	  description 
-	    "The name of parameters to be monitored. 
-		For example, latency, Bit Error Rate, Bandwidth and so on.";
+        "The name of parameters to be monitored. 
+         For example, latency, Bit Error Rate, Bandwidth and so on.";
 	}
 	list parameter-value {
 	  key value; 

--- a/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
+++ b/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
@@ -205,13 +205,13 @@ module ietf-eth-service-pm {
           description 
             "The operational status of the services.";
         }
-		container alarm {
-		  leaf status {
-		    type identityref {
-		      base ethsvc-pm:alarm-status;
-		    }
-		  }
-		}
+        container alarm {
+          leaf status {
+            type identityref {
+              base ethsvc-pm:alarm-status;
+            }
+          }
+        }
       }
     }
   }

--- a/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
+++ b/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
@@ -61,11 +61,11 @@ module ietf-eth-service-pm {
     {
       type union {
         type uint32;
-		type uint64;
-		type decimal64 {
+        type uint64;
+        type decimal64 {
           fraction-digits 6;
         }
-		type string; 
+        type string; 
       }
       description
         "To represent the type of value. ";

--- a/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
+++ b/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
@@ -168,17 +168,17 @@ module ietf-eth-service-pm {
         description 
           "The state of service performance monitoring.";		  
 		
-		list performance-data{
-	      key parameter-name; 
-	      description "The list of performance under monitor.";
-	      uses service-performance-monitor-set;
-	    }
-		
-		leaf monitor-state {
-		  type identityref {
-		    base ethsvc-pm:monitoring-state;
-		  }
-		}
+        list performance-data{
+          key parameter-name; 
+          description "The list of performance under monitor.";
+          uses service-performance-monitor-set;
+        }
+
+        leaf monitor-state {
+          type identityref {
+            base ethsvc-pm:monitoring-state;
+          }
+        }
 		
         leaf start-time {
           type yang:date-and-time;

--- a/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
+++ b/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
@@ -68,7 +68,7 @@ module ietf-eth-service-pm {
         type string; 
       }
       description
-        "To represent the type of value. ";
+        "A performance parameter value.";
     }
 	
   identity performance-parameter-type {

--- a/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
+++ b/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
@@ -73,7 +73,7 @@ module ietf-eth-service-pm {
 	
   identity performance-type {
     description
-      "Base type of performance monitoring. ";
+      "Base type of the performance parameter being monitored. ";
   }
 
   identity latency {

--- a/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
+++ b/YANG/ccamp/client-pm/ietf-eth-service-pm.yang
@@ -57,7 +57,7 @@ module ietf-eth-service-pm {
       "ADD REFERENCE HERE";
   }
 
-  typedef performance-parameter
+  typedef performance-parameter-value
     {
       type union {
         type uint32;


### PR DESCRIPTION
Update only Ethernet part. 
1. add a generic grouping for parameter value representation; 
2. add monitor-state/alarm-state which are usually associated with performance monitoring; 
3. add vlan-id to specify the C-VLAN. 

Plan: 
1. Present and collect feedback in ccamp interim; 
2. Do the similar logic to transparent client signal model; 
3. after plan 2, probably extract some common groupings/identities/typedefs to form a common pm-type. 