### PR TITLE
Updated Layer 1 types YANG and JSON

### DIFF
--- a/YANG/ccamp/layer1-types/ietf-layer1-types.yang
+++ b/YANG/ccamp/layer1-types/ietf-layer1-types.yang
@@ -1101,38 +1101,42 @@ module ietf-layer1-types {
     description "OTN Label";
     reference
       "RFC7139, section 6: GMPLS Signaling Extensions for Control of
-       Evolving G.709 Optical Transport Networks"; 
-    leaf otn-tpn {
-      type otn-tpn;
+       Evolving G.709 Optical Transport Networks";
+    container otn {
       description
-        "Tributary Port Number.";
-      reference
-        "RFC7139: GMPLS Signaling Extensions for Control of Evolving
-         G.709 Optical Transport Networks.";
-    }
-    leaf tsg {
-      type identityref {
-        base tributary-slot-granularity;
+        "TE Label for OTN.";
+      leaf otn-tpn {
+        type otn-tpn;
+        description
+          "Tributary Port Number.";
+        reference
+          "RFC7139: GMPLS Signaling Extensions for Control of
+          Evolving G.709 Optical Transport Networks.";
       }
-      description "Tributary slot granularity.";
-      reference
-        "ITU-T G.709 v6.0 (06/2020): Interfaces for the Optical
-         Transport Network (OTN)";
-    }
-    leaf ts-list {
-      type string {
-          pattern "([1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?"
-                + "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
+      leaf tsg {
+        type identityref {
+          base tributary-slot-granularity;
         }
-      description
-        "A list of available tributary slots ranging
-         between 1 and 4095. If multiple values or  
-         ranges are given, they all must be disjoint 
-         and must be in ascending order.
-         For example 1-20,25,50-1000.";
-      reference 
-        "RFC 7139: GMPLS Signaling Extensions for Control
-         of Evolving G.709 Optical Transport Networks";
+        description "Tributary slot granularity.";
+        reference
+          "ITU-T G.709 v6.0 (06/2020): Interfaces for the Optical
+          Transport Network (OTN)";
+      }
+      leaf ts-list {
+        type string {
+            pattern "([1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?"
+                  + "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
+          }
+        description
+          "A list of available tributary slots ranging
+          between 1 and 4095. If multiple values or  
+          ranges are given, they all must be disjoint 
+          and must be in ascending order.
+          For example 1-20,25,50-1000.";
+        reference 
+          "RFC 7139: GMPLS Signaling Extensions for Control
+          of Evolving G.709 Optical Transport Networks";
+      }
     }
   }
   
@@ -1145,9 +1149,9 @@ module ietf-layer1-types {
 
        This grouping should be used together with the
        otn-label-range-info and otn-label-start-end groupings to
-       provide OTN technology-specific label information to the models
-       which use the label-restriction-info grouping defined in the
-       module ietf-te-types.";
+       provide OTN technology-specific label information to the
+       models which use the label-restriction-info grouping defined
+       in the module ietf-te-types.";
     choice range-type {
       description
         "OTN label range type, either TPN range or TS range";

--- a/YANG/ccamp/layer1-types/ietf-layer1-types.yang
+++ b/YANG/ccamp/layer1-types/ietf-layer1-types.yang
@@ -31,7 +31,7 @@ module ietf-layer1-types {
      This version of this YANG module is part of RFC XXXX; see
      the RFC itself for full legal notices.";
 
-  revision "2022-03-24" {
+  revision "2022-04-07" {
     description
       "Initial Version";
     reference
@@ -1078,7 +1078,7 @@ module ietf-layer1-types {
         description
           "OTN label range type, either TPN range or TS range";
         case trib-port {
-          leaf otn-tpn {
+          leaf tpn {
             when "../../../../otn-label-range/range-type = 
                   'trib-port'" {
               description 
@@ -1087,14 +1087,14 @@ module ietf-layer1-types {
             } 
             type otn-tpn;
             description
-              "Tributary Port Number.";
+              "Tributary Port Number (TPN).";
             reference
               "RFC7139: GMPLS Signaling Extensions for Control of
               Evolving G.709 Optical Transport Networks.";
           }
         }
         case trib-slot {
-          leaf otn-ts {
+          leaf ts {
             when "../../../../otn-label-range/range-type = 
                   'trib-slot'" {
               description 
@@ -1103,7 +1103,7 @@ module ietf-layer1-types {
             } 
             type otn-ts;
             description
-              "Tributary Slot Number.";
+              "Tributary Slot (TS) number.";
             reference
               "RFC7139: GMPLS Signaling Extensions for Control of
               Evolving G.709 Optical Transport Networks";
@@ -1121,10 +1121,10 @@ module ietf-layer1-types {
     container otn {
       description
         "Label hop for OTN.";
-      leaf otn-tpn {
+      leaf tpn {
         type otn-tpn;
         description
-          "Tributary Port Number.";
+          "Tributary Port Number (TPN).";
         reference
           "RFC7139: GMPLS Signaling Extensions for Control of
           Evolving G.709 Optical Transport Networks.";
@@ -1133,7 +1133,7 @@ module ietf-layer1-types {
         type identityref {
           base tributary-slot-granularity;
         }
-        description "Tributary slot granularity.";
+        description "Tributary Slot Granularity (TSG).";
         reference
           "ITU-T G.709 v6.0 (06/2020): Interfaces for the Optical
           Transport Network (OTN)";
@@ -1144,7 +1144,7 @@ module ietf-layer1-types {
                   + "(,[1-9][0-9]{0,3}(-[1-9][0-9]{0,3})?)*)";
           }
         description
-          "A list of available tributary slots ranging
+          "A list of available Tributary Slots (TS) ranging
           between 1 and 4095. If multiple values or  
           ranges are given, they all must be disjoint 
           and must be in ascending order.
@@ -1175,7 +1175,7 @@ module ietf-layer1-types {
         description
           "OTN label range type, either TPN range or TS range";
         case trib-port {
-          leaf otn-tpn {
+          leaf tpn {
             when "../../../otn-label-range/range-type = 
                   'trib-port'" {
               description 
@@ -1185,14 +1185,14 @@ module ietf-layer1-types {
             type otn-tpn;
             description
               "Label step which represents possible increments for 
-              Tributary Port Number.";
+              Tributary Port Number (TPN).";
             reference
               "RFC7139: GMPLS Signaling Extensions for Control of 
               Evolving G.709 Optical Transport Networks.";
           }
         }
         case trib-slot {
-          leaf otn-ts {
+          leaf ts {
             when "../../../otn-label-range/range-type = 
                   'trib-slot'" {
               description 
@@ -1202,7 +1202,7 @@ module ietf-layer1-types {
             type otn-ts; 
             description
               "Label step which represents possible increments for 
-              Tributary Slot Number.";
+              Tributary Slot (TS) number.";
             reference
               "RFC7139: GMPLS Signaling Extensions for Control of
               Evolving G.709 Optical Transport Networks.";

--- a/YANG/ccamp/layer1-types/ietf-layer1-types.yang
+++ b/YANG/ccamp/layer1-types/ietf-layer1-types.yang
@@ -31,7 +31,7 @@ module ietf-layer1-types {
      This version of this YANG module is part of RFC XXXX; see
      the RFC itself for full legal notices.";
 
-  revision "2022-03-10" {
+  revision "2022-03-24" {
     description
       "Initial Version";
     reference
@@ -881,19 +881,23 @@ module ietf-layer1-types {
   grouping otn-link-bandwidth {
     description
       "Bandwidth attributes for OTN links";
-    list odulist {
-      key "odu-type";
+    container otn {
       description
-        "OTN bandwidth definition";
-      leaf odu-type {
-        type identityref {
-          base odu-type;
+        "Bandwidth attributes for OTN links";
+      list odulist {
+        key "odu-type";
+        description
+          "OTN bandwidth definition";
+        leaf odu-type {
+          type identityref {
+            base odu-type;
+          }
+          description "ODU type";
         }
-        description "ODU type";
-      }
-      leaf number {
-        type uint16;
-        description "Number of ODUs";
+        leaf number {
+          type uint16;
+          description "Number of ODUs";
+        }
       }
     }
   }
@@ -1007,46 +1011,50 @@ module ietf-layer1-types {
        OTN technology-specific label information to the models which
        use the label-restriction-info grouping defined in the module
        ietf-te-types.";
-    leaf range-type {
-      type otn-label-range-type;
-      description "The type of range (e.g., TPN or TS)
-         to which the label range applies";
-    }
-    leaf tsg {
-      type identityref {
-        base tributary-slot-granularity;
+    container otn-label-range {
+      description
+        "Label range information for OTN.";
+      leaf range-type {
+        type otn-label-range-type;
+        description "The type of range (e.g., TPN or TS)
+          to which the label range applies";
       }
-      description 
-        "Tributary slot granularity (TSG) to which the label range 
-         applies.
+      leaf tsg {
+        type identityref {
+          base tributary-slot-granularity;
+        }
+        description 
+          "Tributary slot granularity (TSG) to which the label range 
+          applies.
 
-         This leaf shall be present when the range-type is TS.
+          This leaf shall be present when the range-type is TS.
 
-         This leaf can be omitted when mapping an ODUk over an OTUk
-         Link. In this case the range-type is tpn, with only one
-         entry (ODUk), and the tpn range has only one value (1).";
-      reference
-        "ITU-T G.709 v6.0 (06/2020): Interfaces for the Optical
-         Transport Network (OTN)";
-    }
-    leaf-list odu-type-list {
-      type identityref {
-        base odu-type;
+          This leaf can be omitted when mapping an ODUk over an OTUk
+          Link. In this case the range-type is tpn, with only one
+          entry (ODUk), and the tpn range has only one value (1).";
+        reference
+          "ITU-T G.709 v6.0 (06/2020): Interfaces for the Optical
+          Transport Network (OTN)";
       }
-      description 
-        "List of ODU types to which the label range applies.
+      leaf-list odu-type-list {
+        type identityref {
+          base odu-type;
+        }
+        description 
+          "List of ODU types to which the label range applies.
 
-         An Empty odu-type-list means that the label range
-         applies to all the supported ODU types.";
-    } 
-    leaf priority {
-      type uint8;
-      description 
-        "Priority in Interface Switching Capability 
-         Descriptor (ISCD).";
-      reference
-        "RFC4203: OSPF Extensions in Support of Generalized
-         Multi-Protocol Label Switching (GMPLS)";
+          An Empty odu-type-list means that the label range
+          applies to all the supported ODU types.";
+      } 
+      leaf priority {
+        type uint8;
+        description 
+          "Priority in Interface Switching Capability 
+          Descriptor (ISCD).";
+        reference
+          "RFC4203: OSPF Extensions in Support of Generalized
+          Multi-Protocol Label Switching (GMPLS)";
+      }
     }
   }
 
@@ -1063,35 +1071,43 @@ module ietf-layer1-types {
        OTN technology-specific label information to the models which
        use the label-restriction-info grouping defined in the module
        ietf-te-types.";
-    choice range-type {
+    container otn {
       description
-        "OTN label range type, either TPN range or TS range";
-      case trib-port {
-        leaf otn-tpn {
-          when "../../../range-type = 'trib-port'" {
-            description 
-              "Valid only when range-type represented by trib-port";
-          } 
-          type otn-tpn;
-          description
-            "Tributary Port Number.";
-          reference
-            "RFC7139: GMPLS Signaling Extensions for Control of
-             Evolving G.709 Optical Transport Networks.";
+        "Label start or label end for OTN.";
+      choice range-type {
+        description
+          "OTN label range type, either TPN range or TS range";
+        case trib-port {
+          leaf otn-tpn {
+            when "../../../../otn-label-range/range-type = 
+                  'trib-port'" {
+              description 
+                "Valid only when range-type represented by
+                trib-port";
+            } 
+            type otn-tpn;
+            description
+              "Tributary Port Number.";
+            reference
+              "RFC7139: GMPLS Signaling Extensions for Control of
+              Evolving G.709 Optical Transport Networks.";
+          }
         }
-      }
-      case trib-slot {
-        leaf otn-ts {
-          when "../../../range-type = 'trib-slot'" {
-            description 
-              "Valid only when range-type represented by trib-slot";
-          } 
-          type otn-ts;
-          description
-            "Tributary Slot Number.";
-          reference
-            "RFC7139: GMPLS Signaling Extensions for Control of
-             Evolving G.709 Optical Transport Networks";
+        case trib-slot {
+          leaf otn-ts {
+            when "../../../../otn-label-range/range-type = 
+                  'trib-slot'" {
+              description 
+                "Valid only when range-type represented by
+                trib-slot";
+            } 
+            type otn-ts;
+            description
+              "Tributary Slot Number.";
+            reference
+              "RFC7139: GMPLS Signaling Extensions for Control of
+              Evolving G.709 Optical Transport Networks";
+          }
         }
       }
     }
@@ -1104,7 +1120,7 @@ module ietf-layer1-types {
        Evolving G.709 Optical Transport Networks";
     container otn {
       description
-        "TE Label for OTN.";
+        "Label hop for OTN.";
       leaf otn-tpn {
         type otn-tpn;
         description
@@ -1152,37 +1168,45 @@ module ietf-layer1-types {
        provide OTN technology-specific label information to the
        models which use the label-restriction-info grouping defined
        in the module ietf-te-types.";
-    choice range-type {
+    container otn {
       description
-        "OTN label range type, either TPN range or TS range";
-      case trib-port {
-        leaf otn-tpn {
-          when "../../range-type = 'trib-port'" {
-            description 
-              "Valid only when range-type represented by trib-port";
-          } 
-          type otn-tpn;
-          description
-            "Label step which represents possible increments for 
-             Tributary Port Number.";
-          reference
-            "RFC7139: GMPLS Signaling Extensions for Control of 
-             Evolving G.709 Optical Transport Networks.";
+        "Label step for OTN";
+      choice range-type {
+        description
+          "OTN label range type, either TPN range or TS range";
+        case trib-port {
+          leaf otn-tpn {
+            when "../../../otn-label-range/range-type = 
+                  'trib-port'" {
+              description 
+                "Valid only when range-type represented by
+                trib-port";
+            } 
+            type otn-tpn;
+            description
+              "Label step which represents possible increments for 
+              Tributary Port Number.";
+            reference
+              "RFC7139: GMPLS Signaling Extensions for Control of 
+              Evolving G.709 Optical Transport Networks.";
+          }
         }
-      }
-      case trib-slot {
-        leaf otn-ts {
-          when "../../range-type = 'trib-slot'" {
-            description 
-              "Valid only when range-type represented by trib-slot";
-          } 
-          type otn-ts; 
-          description
-            "Label step which represents possible increments for 
-             Tributary Slot Number.";
-          reference
-            "RFC7139: GMPLS Signaling Extensions for Control of
-             Evolving G.709 Optical Transport Networks.";
+        case trib-slot {
+          leaf otn-ts {
+            when "../../../otn-label-range/range-type = 
+                  'trib-slot'" {
+              description 
+                "Valid only when range-type represented by
+                trib-slot";
+            } 
+            type otn-ts; 
+            description
+              "Label step which represents possible increments for 
+              Tributary Slot Number.";
+            reference
+              "RFC7139: GMPLS Signaling Extensions for Control of
+              Evolving G.709 Optical Transport Networks.";
+          }
         }
       }
     }

--- a/YANG/ccamp/layer1-types/odu-label-restrictions-examples.json
+++ b/YANG/ccamp/layer1-types/odu-label-restrictions-examples.json
@@ -7,19 +7,24 @@
           {
             "index ": 1,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "// not-present tsg": "",
-            "odu-type-list": "[ ODU1 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "// not-present tsg": "",
+              "odu-type-list": "[ ODU1 ]",
+              "// default priority": 7
+            },
             "// tpn-range": 1,
             "// comment": "Since no TS range and no TSG are reported for ODU1, the link is an OTU1 Link. TS allocation is not needed and TPN shall be set to '1' for mapping ODU1 over OTU1. This entry is not present if the OTN Link is an HO-ODU1 Link."
           },
           {
             "index ": 2,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODU0 ]",
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODU0 ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-2",
             "// comment": "Since no TPN range is reportd for ODU0 with 1.25G TSG, the TPN allocation rule is fixed (TPN = TS#) for mapping LO-ODU0 over HO-ODU1 with 1.25G TSG. See Table 4 of [RFC7139]."
           }
@@ -33,49 +38,59 @@
           {
             "index ": 1,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "//not-present tsg": "",
-            "odu-type-list": "[ ODU2 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "//not-present tsg": "",
+              "odu-type-list": "[ ODU2 ]",
+              "// default priority": 7
+            },
             "// tpn-range": 1,
             "// comment": "Since no TS range and no TSG are reported for ODU2, the link is an OTU2 Link. TS allocation is not needed and TPN shall be set to '1' for mapping ODU2 over OTU2. This entry is not present if the OTN Link is an HO-ODU2 Link."
           },
           {
             "index ": 2,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1 ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-8"
           },
           {
             "index ": 3,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-1.25G ",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-1.25G ",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-8",
             "// comment": "Since this TPN range is reported for ODUflex and ODU0 with 1.25G TSG, the TPN assignment rule is flexible within a common range for mapping LO-ODUflex and LO-ODU0 over HO-ODU2 with 1.25G TSG. See Table 4 of [RFC7139]."
           },
           {
             "index ": 4,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODU1 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODU1 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-4",
             "// comment": "Since this TPN range is reported for ODU1 with 1.25G TSG, the TPN assignment rule is flexible within a common range for mapping LO-ODU1 over HO-ODU2 with 1.25G TSG. See Table 4 of [RFC7139]."
           },
           {
             "index ": 5,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-2.5G",
-            "odu-type-list": "[ ODU1 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-2.5G",
+              "odu-type-list": "[ ODU1 ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-4",
             "// comment": "Since no TPN range is reported for ODU1 with 2.5G TSG, the TPN allocation rule is fixed (TPN = TS#) for mapping LO-ODU1 over HO-ODU2 with 2.5G TSG. See Table 3 of [RFC7139]."
           }
@@ -89,68 +104,82 @@
           {
             "index ": 1,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "//not-present tsg": "",
-            "odu-type-list": "[ ODU3 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "//not-present tsg": "",
+              "odu-type-list": "[ ODU3 ]",
+              "// default priority": 7
+            },
             "// tpn-range": 1,
             "// comment": "Since no TS range and no TSG are reported for ODU3, the link is an OTU3 Link. TS allocation is not needed and TPN shall be set to '1' for mapping ODU3 over OTU3. This entry is not present if the OTN Link is an HO-ODU3 Link."
           },
           {
             "index ": 2,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-32"
           },
           {
             "index ": 3,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU2e ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU2e ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-32",
             "// comment": "Since this TPN range is reported for ODUflex, ODU0 and ODU2e with 1.25G TSG, the TPN assignment rule is flexible within a common range for mapping LO-ODUflex, LO-ODU0 and LO-ODU2e over HO-ODU3 with 1.25G TSG. See Table 4 of [RFC7139]."
           },
           {
             "index ": 4,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODU1 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODU1 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-16",
             "// comment": "Since this TPN range is reported for ODU1 with 1.25G TSG, the TPN assignment rule is flexible within a common range for mapping LO-ODU1 over HO-ODU3 with 1.25G TSG. See Table 4 of [RFC7139]."
           },
           {
             "index ": 5,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODU2 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODU2 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-4",
             "// comment": "Since this TPN range is reported for ODU2 with 1.25G TSG, the TPN assignment rule is flexible within a common range for mapping LO-ODU2 over HO-ODU3 with 1.25G TSG. See Table 4 of [RFC7139]."
           },
           {
             "index ": 6,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-2.5G",
-            "odu-type-list": "[ ODU1, ODU2 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-2.5G",
+              "odu-type-list": "[ ODU1, ODU2 ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-16"
           },
           {
             "index ": 7,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-2.5G ",
-            "odu-type-list": "[ ODU2 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-2.5G ",
+              "odu-type-list": "[ ODU2 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-4",
             "// comment": "Since this TPN range is reported for ODU2 with 2.5G TSG, the TPN assignment rule is flexible within a common range for mapping LO-ODU2 over HO-ODU3. Since no TPN range is reported for ODU1 with 2.5G TSG, the TPN allocation rule is fixed (TPN = TS#) for mapping LO-ODU1 over HO-ODU3 with 2.5G TSG. See Table 3 of [RFC7139]."
           }
@@ -164,29 +193,35 @@
           {
             "index ": 1,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "//not-present tsg": "",
-            "odu-type-list": "[ ODU4 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "//not-present tsg": "",
+              "odu-type-list": "[ ODU4 ]",
+              "// default priority": 7
+            },
             "// tpn-range": 1,
             "// comment": "Since no TS range and no TSG are reported for ODU4, the link is an OTU4 Link. TS allocation is not needed and TPN shall be set to '1' for mapping ODU4 over OTU4. This entry is not present if the OTN Link is an HO-ODU4 Link."
           },
           {
             "index ": 2,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e, ODU3 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e, ODU3 ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-80"
           },
           {
             "index ": 3,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e, ODU3 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e, ODU3 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-80",
             "// comment": "Since this TPN range is reported for any LO-ODUj with 1.25G TSG, the TPN assignment rule is flexible within a common range for mapping any LO-ODUj over HO-ODU4 with 1.25G TSG. See Table 4 of [RFC7139]."
           }
@@ -200,20 +235,24 @@
           {
             "index ": 1,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-5G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e, ODU3, ODU4 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-5G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e, ODU3, ODU4 ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-20",
             "// comment": "Since the TS range is specified for any ODUk, the OTN Link is an ODUCn Link."
           },
           {
             "index ": 2,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-5G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e, ODU3, ODU4 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-5G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e, ODU3, ODU4 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-10",
             "// comment": "Since this TPN range is reported for any ODUk with 5G TSG, the TPN assignment rule is flexible within a common range for mapping any ODUk over ODUCn with 5G TSG."
           }

--- a/YANG/ccamp/layer1-types/odu-label-restrictions-examples.json
+++ b/YANG/ccamp/layer1-types/odu-label-restrictions-examples.json
@@ -1,0 +1,224 @@
+{
+  "// examples of label-restrictions for different OTN Links": [
+    {
+      "// example": "HO-ODU1 or OTU1 Link",
+      "label-restrictions": {
+        "label-restriction": [
+          {
+            "index ": 1,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "// not-present tsg": "",
+            "odu-type-list": "[ ODU1 ]",
+            "// default priority": 7,
+            "// tpn-range": 1,
+            "// comment": "Since no TS range and no TSG are reported for ODU1, the link is an OTU1 Link. TS allocation is not needed and TPN shall be set to '1' for mapping ODU1 over OTU1. This entry is not present if the OTN Link is an HO-ODU1 Link."
+          },
+          {
+            "index ": 2,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODU0 ]",
+            "// ts-range": "1-2",
+            "// comment": "Since no TPN range is reportd for ODU0 with 1.25G TSG, the TPN allocation rule is fixed (TPN = TS#) for mapping LO-ODU0 over HO-ODU1 with 1.25G TSG. See Table 4 of [RFC7139]."
+          }
+        ]
+      }
+    },
+    {
+      "// example": "HO-ODU2 or OTU2 Link",
+      "label-restrictions": {
+        "label-restriction": [
+          {
+            "index ": 1,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "//not-present tsg": "",
+            "odu-type-list": "[ ODU2 ]",
+            "// default priority": 7,
+            "// tpn-range": 1,
+            "// comment": "Since no TS range and no TSG are reported for ODU2, the link is an OTU2 Link. TS allocation is not needed and TPN shall be set to '1' for mapping ODU2 over OTU2. This entry is not present if the OTN Link is an HO-ODU2 Link."
+          },
+          {
+            "index ": 2,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1 ]",
+            "// default priority": 7,
+            "// ts-range": "1-8"
+          },
+          {
+            "index ": 3,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-1.25G ",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-8",
+            "// comment": "Since this TPN range is reported for ODUflex and ODU0 with 1.25G TSG, the TPN assignment rule is flexible within a common range for mapping LO-ODUflex and LO-ODU0 over HO-ODU2 with 1.25G TSG. See Table 4 of [RFC7139]."
+          },
+          {
+            "index ": 4,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODU1 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-4",
+            "// comment": "Since this TPN range is reported for ODU1 with 1.25G TSG, the TPN assignment rule is flexible within a common range for mapping LO-ODU1 over HO-ODU2 with 1.25G TSG. See Table 4 of [RFC7139]."
+          },
+          {
+            "index ": 5,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-2.5G",
+            "odu-type-list": "[ ODU1 ]",
+            "// default priority": 7,
+            "// ts-range": "1-4",
+            "// comment": "Since no TPN range is reported for ODU1 with 2.5G TSG, the TPN allocation rule is fixed (TPN = TS#) for mapping LO-ODU1 over HO-ODU2 with 2.5G TSG. See Table 3 of [RFC7139]."
+          }
+        ]
+      }
+    },
+    {
+      "// example": "HO-ODU3 or OTU3 Link",
+      "label-restrictions": {
+        "label-restriction": [
+          {
+            "index ": 1,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "//not-present tsg": "",
+            "odu-type-list": "[ ODU3 ]",
+            "// default priority": 7,
+            "// tpn-range": 1,
+            "// comment": "Since no TS range and no TSG are reported for ODU3, the link is an OTU3 Link. TS allocation is not needed and TPN shall be set to '1' for mapping ODU3 over OTU3. This entry is not present if the OTN Link is an HO-ODU3 Link."
+          },
+          {
+            "index ": 2,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e ]",
+            "// default priority": 7,
+            "// ts-range": "1-32"
+          },
+          {
+            "index ": 3,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU2e ]",
+            "// default priority": 7,
+            "// tpn-range": "1-32",
+            "// comment": "Since this TPN range is reported for ODUflex, ODU0 and ODU2e with 1.25G TSG, the TPN assignment rule is flexible within a common range for mapping LO-ODUflex, LO-ODU0 and LO-ODU2e over HO-ODU3 with 1.25G TSG. See Table 4 of [RFC7139]."
+          },
+          {
+            "index ": 4,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODU1 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-16",
+            "// comment": "Since this TPN range is reported for ODU1 with 1.25G TSG, the TPN assignment rule is flexible within a common range for mapping LO-ODU1 over HO-ODU3 with 1.25G TSG. See Table 4 of [RFC7139]."
+          },
+          {
+            "index ": 5,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODU2 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-4",
+            "// comment": "Since this TPN range is reported for ODU2 with 1.25G TSG, the TPN assignment rule is flexible within a common range for mapping LO-ODU2 over HO-ODU3 with 1.25G TSG. See Table 4 of [RFC7139]."
+          },
+          {
+            "index ": 6,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-2.5G",
+            "odu-type-list": "[ ODU1, ODU2 ]",
+            "// default priority": 7,
+            "// ts-range": "1-16"
+          },
+          {
+            "index ": 7,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-2.5G ",
+            "odu-type-list": "[ ODU2 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-4",
+            "// comment": "Since this TPN range is reported for ODU2 with 2.5G TSG, the TPN assignment rule is flexible within a common range for mapping LO-ODU2 over HO-ODU3. Since no TPN range is reported for ODU1 with 2.5G TSG, the TPN allocation rule is fixed (TPN = TS#) for mapping LO-ODU1 over HO-ODU3 with 2.5G TSG. See Table 3 of [RFC7139]."
+          }
+        ]
+      }
+    },
+    {
+      "// example": "HO-ODU4 or OTU4 Link",
+      "label-restrictions": {
+        "label-restriction": [
+          {
+            "index ": 1,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "//not-present tsg": "",
+            "odu-type-list": "[ ODU4 ]",
+            "// default priority": 7,
+            "// tpn-range": 1,
+            "// comment": "Since no TS range and no TSG are reported for ODU4, the link is an OTU4 Link. TS allocation is not needed and TPN shall be set to '1' for mapping ODU4 over OTU4. This entry is not present if the OTN Link is an HO-ODU4 Link."
+          },
+          {
+            "index ": 2,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e, ODU3 ]",
+            "// default priority": 7,
+            "// ts-range": "1-80"
+          },
+          {
+            "index ": 3,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e, ODU3 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-80",
+            "// comment": "Since this TPN range is reported for any LO-ODUj with 1.25G TSG, the TPN assignment rule is flexible within a common range for mapping any LO-ODUj over HO-ODU4 with 1.25G TSG. See Table 4 of [RFC7139]."
+          }
+        ]
+      }
+    },
+    {
+      "// example": "ODUC1 Link",
+      "label-restrictions": {
+        "label-restriction": [
+          {
+            "index ": 1,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-5G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e, ODU3, ODU4 ]",
+            "// default priority": 7,
+            "// ts-range": "1-20",
+            "// comment": "Since the TS range is specified for any ODUk, the OTN Link is an ODUCn Link."
+          },
+          {
+            "index ": 2,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-5G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1, ODU2, ODU2e, ODU3, ODU4 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-10",
+            "// comment": "Since this TPN range is reported for any ODUk with 5G TSG, the TPN assignment rule is flexible within a common range for mapping any ODUk over ODUCn with 5G TSG."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/YANG/ccamp/layer1-types/odu-label-restrictions-examples.txt
+++ b/YANG/ccamp/layer1-types/odu-label-restrictions-examples.txt
@@ -1,0 +1,275 @@
+=============== NOTE: '\\' line wrapping per RFC 8792 ===============
+
+{
+  "// examples of label-restrictions for different OTN Links": [
+    {
+      "// example": "HO-ODU1 or OTU1 Link",
+      "label-restrictions": {
+        "label-restriction": [
+          {
+            "index ": 1,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "// not-present tsg": "",
+            "odu-type-list": "[ ODU1 ]",
+            "// default priority": 7,
+            "// tpn-range": 1,
+            "// comment": "Since no TS range and no TSG are reported\
+\ for ODU1, the link is an OTU1 Link. TS allocation is not needed an\
+\d TPN shall be set to '1' for mapping ODU1 over OTU1. This entry is\
+\ not present if the OTN Link is an HO-ODU1 Link."
+          },
+          {
+            "index ": 2,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODU0 ]",
+            "// ts-range": "1-2",
+            "// comment": "Since no TPN range is reportd for ODU0 wi\
+\th 1.25G TSG, the TPN allocation rule is fixed (TPN = TS#) for mapp\
+\ing LO-ODU0 over HO-ODU1 with 1.25G TSG. See Table 4 of [RFC7139]."
+          }
+        ]
+      }
+    },
+    {
+      "// example": "HO-ODU2 or OTU2 Link",
+      "label-restrictions": {
+        "label-restriction": [
+          {
+            "index ": 1,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "//not-present tsg": "",
+            "odu-type-list": "[ ODU2 ]",
+            "// default priority": 7,
+            "// tpn-range": 1,
+            "// comment": "Since no TS range and no TSG are reported\
+\ for ODU2, the link is an OTU2 Link. TS allocation is not needed an\
+\d TPN shall be set to '1' for mapping ODU2 over OTU2. This entry is\
+\ not present if the OTN Link is an HO-ODU2 Link."
+          },
+          {
+            "index ": 2,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1\
+\ ]",
+            "// default priority": 7,
+            "// ts-range": "1-8"
+          },
+          {
+            "index ": 3,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-1.25G ",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-8",
+            "// comment": "Since this TPN range is reported for ODUf\
+\lex and ODU0 with 1.25G TSG, the TPN assignment rule is flexible wi\
+\thin a common range for mapping LO-ODUflex and LO-ODU0 over HO-ODU2\
+\ with 1.25G TSG. See Table 4 of [RFC7139]."
+          },
+          {
+            "index ": 4,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODU1 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-4",
+            "// comment": "Since this TPN range is reported for ODU1\
+\ with 1.25G TSG, the TPN assignment rule is flexible within a commo\
+\n range for mapping LO-ODU1 over HO-ODU2 with 1.25G TSG. See Table \
+\4 of [RFC7139]."
+          },
+          {
+            "index ": 5,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-2.5G",
+            "odu-type-list": "[ ODU1 ]",
+            "// default priority": 7,
+            "// ts-range": "1-4",
+            "// comment": "Since no TPN range is reported for ODU1 w\
+\ith 2.5G TSG, the TPN allocation rule is fixed (TPN = TS#) for mapp\
+\ing LO-ODU1 over HO-ODU2 with 2.5G TSG. See Table 3 of [RFC7139]."
+          }
+        ]
+      }
+    },
+    {
+      "// example": "HO-ODU3 or OTU3 Link",
+      "label-restrictions": {
+        "label-restriction": [
+          {
+            "index ": 1,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "//not-present tsg": "",
+            "odu-type-list": "[ ODU3 ]",
+            "// default priority": 7,
+            "// tpn-range": 1,
+            "// comment": "Since no TS range and no TSG are reported\
+\ for ODU3, the link is an OTU3 Link. TS allocation is not needed an\
+\d TPN shall be set to '1' for mapping ODU3 over OTU3. This entry is\
+\ not present if the OTN Link is an HO-ODU3 Link."
+          },
+          {
+            "index ": 2,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1\
+\, ODU2, ODU2e ]",
+            "// default priority": 7,
+            "// ts-range": "1-32"
+          },
+          {
+            "index ": 3,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU2\
+\e ]",
+            "// default priority": 7,
+            "// tpn-range": "1-32",
+            "// comment": "Since this TPN range is reported for ODUf\
+\lex, ODU0 and ODU2e with 1.25G TSG, the TPN assignment rule is flex\
+\ible within a common range for mapping LO-ODUflex, LO-ODU0 and LO-O\
+\DU2e over HO-ODU3 with 1.25G TSG. See Table 4 of [RFC7139]."
+          },
+          {
+            "index ": 4,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODU1 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-16",
+            "// comment": "Since this TPN range is reported for ODU1\
+\ with 1.25G TSG, the TPN assignment rule is flexible within a commo\
+\n range for mapping LO-ODU1 over HO-ODU3 with 1.25G TSG. See Table \
+\4 of [RFC7139]."
+          },
+          {
+            "index ": 5,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODU2 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-4",
+            "// comment": "Since this TPN range is reported for ODU2\
+\ with 1.25G TSG, the TPN assignment rule is flexible within a commo\
+\n range for mapping LO-ODU2 over HO-ODU3 with 1.25G TSG. See Table \
+\4 of [RFC7139]."
+          },
+          {
+            "index ": 6,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-2.5G",
+            "odu-type-list": "[ ODU1, ODU2 ]",
+            "// default priority": 7,
+            "// ts-range": "1-16"
+          },
+          {
+            "index ": 7,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-2.5G ",
+            "odu-type-list": "[ ODU2 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-4",
+            "// comment": "Since this TPN range is reported for ODU2\
+\ with 2.5G TSG, the TPN assignment rule is flexible within a common\
+\ range for mapping LO-ODU2 over HO-ODU3. Since no TPN range is repo\
+\rted for ODU1 with 2.5G TSG, the TPN allocation rule is fixed (TPN \
+\= TS#) for mapping LO-ODU1 over HO-ODU3 with 2.5G TSG. See Table 3 \
+\of [RFC7139]."
+          }
+        ]
+      }
+    },
+    {
+      "// example": "HO-ODU4 or OTU4 Link",
+      "label-restrictions": {
+        "label-restriction": [
+          {
+            "index ": 1,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "//not-present tsg": "",
+            "odu-type-list": "[ ODU4 ]",
+            "// default priority": 7,
+            "// tpn-range": 1,
+            "// comment": "Since no TS range and no TSG are reported\
+\ for ODU4, the link is an OTU4 Link. TS allocation is not needed an\
+\d TPN shall be set to '1' for mapping ODU4 over OTU4. This entry is\
+\ not present if the OTN Link is an HO-ODU4 Link."
+          },
+          {
+            "index ": 2,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1\
+\, ODU2, ODU2e, ODU3 ]",
+            "// default priority": 7,
+            "// ts-range": "1-80"
+          },
+          {
+            "index ": 3,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-1.25G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1\
+\, ODU2, ODU2e, ODU3 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-80",
+            "// comment": "Since this TPN range is reported for any \
+\LO-ODUj with 1.25G TSG, the TPN assignment rule is flexible within \
+\a common range for mapping any LO-ODUj over HO-ODU4 with 1.25G TSG.\
+\ See Table 4 of [RFC7139]."
+          }
+        ]
+      }
+    },
+    {
+      "// example": "ODUC1 Link",
+      "label-restrictions": {
+        "label-restriction": [
+          {
+            "index ": 1,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-slot",
+            "tsg": "tsg-5G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1\
+\, ODU2, ODU2e, ODU3, ODU4 ]",
+            "// default priority": 7,
+            "// ts-range": "1-20",
+            "// comment": "Since the TS range is specified for any O\
+\DUk, the OTN Link is an ODUCn Link."
+          },
+          {
+            "index ": 2,
+            "// default restriction": "inclusive",
+            "range-type": "label-range-trib-port",
+            "tsg": "tsg-5G",
+            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1\
+\, ODU2, ODU2e, ODU3, ODU4 ]",
+            "// default priority": 7,
+            "// tpn-range": "1-10",
+            "// comment": "Since this TPN range is reported for any \
+\ODUk with 5G TSG, the TPN assignment rule is flexible within a comm\
+\on range for mapping any ODUk over ODUCn with 5G TSG."
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/YANG/ccamp/layer1-types/odu-label-restrictions-examples.txt
+++ b/YANG/ccamp/layer1-types/odu-label-restrictions-examples.txt
@@ -9,10 +9,12 @@
           {
             "index ": 1,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "// not-present tsg": "",
-            "odu-type-list": "[ ODU1 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "// not-present tsg": "",
+              "odu-type-list": "[ ODU1 ]",
+              "// default priority": 7
+            },
             "// tpn-range": 1,
             "// comment": "Since no TS range and no TSG are reported\
 \ for ODU1, the link is an OTU1 Link. TS allocation is not needed an\
@@ -22,9 +24,12 @@
           {
             "index ": 2,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODU0 ]",
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODU0 ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-2",
             "// comment": "Since no TPN range is reportd for ODU0 wi\
 \th 1.25G TSG, the TPN allocation rule is fixed (TPN = TS#) for mapp\
@@ -40,10 +45,12 @@
           {
             "index ": 1,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "//not-present tsg": "",
-            "odu-type-list": "[ ODU2 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "//not-present tsg": "",
+              "odu-type-list": "[ ODU2 ]",
+              "// default priority": 7
+            },
             "// tpn-range": 1,
             "// comment": "Since no TS range and no TSG are reported\
 \ for ODU2, the link is an OTU2 Link. TS allocation is not needed an\
@@ -53,20 +60,24 @@
           {
             "index ": 2,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1\
-\ ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, OD\
+\U1 ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-8"
           },
           {
             "index ": 3,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-1.25G ",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-1.25G ",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-8",
             "// comment": "Since this TPN range is reported for ODUf\
 \lex and ODU0 with 1.25G TSG, the TPN assignment rule is flexible wi\
@@ -76,10 +87,12 @@
           {
             "index ": 4,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODU1 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODU1 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-4",
             "// comment": "Since this TPN range is reported for ODU1\
 \ with 1.25G TSG, the TPN assignment rule is flexible within a commo\
@@ -89,10 +102,12 @@
           {
             "index ": 5,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-2.5G",
-            "odu-type-list": "[ ODU1 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-2.5G",
+              "odu-type-list": "[ ODU1 ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-4",
             "// comment": "Since no TPN range is reported for ODU1 w\
 \ith 2.5G TSG, the TPN allocation rule is fixed (TPN = TS#) for mapp\
@@ -108,10 +123,12 @@
           {
             "index ": 1,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "//not-present tsg": "",
-            "odu-type-list": "[ ODU3 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "//not-present tsg": "",
+              "odu-type-list": "[ ODU3 ]",
+              "// default priority": 7
+            },
             "// tpn-range": 1,
             "// comment": "Since no TS range and no TSG are reported\
 \ for ODU3, the link is an OTU3 Link. TS allocation is not needed an\
@@ -121,21 +138,25 @@
           {
             "index ": 2,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1\
-\, ODU2, ODU2e ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, OD\
+\U1, ODU2, ODU2e ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-32"
           },
           {
             "index ": 3,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU2\
-\e ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, OD\
+\U2e ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-32",
             "// comment": "Since this TPN range is reported for ODUf\
 \lex, ODU0 and ODU2e with 1.25G TSG, the TPN assignment rule is flex\
@@ -145,10 +166,12 @@
           {
             "index ": 4,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODU1 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODU1 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-16",
             "// comment": "Since this TPN range is reported for ODU1\
 \ with 1.25G TSG, the TPN assignment rule is flexible within a commo\
@@ -158,10 +181,12 @@
           {
             "index ": 5,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODU2 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODU2 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-4",
             "// comment": "Since this TPN range is reported for ODU2\
 \ with 1.25G TSG, the TPN assignment rule is flexible within a commo\
@@ -171,19 +196,23 @@
           {
             "index ": 6,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-2.5G",
-            "odu-type-list": "[ ODU1, ODU2 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-2.5G",
+              "odu-type-list": "[ ODU1, ODU2 ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-16"
           },
           {
             "index ": 7,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-2.5G ",
-            "odu-type-list": "[ ODU2 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-2.5G ",
+              "odu-type-list": "[ ODU2 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-4",
             "// comment": "Since this TPN range is reported for ODU2\
 \ with 2.5G TSG, the TPN assignment rule is flexible within a common\
@@ -202,10 +231,12 @@
           {
             "index ": 1,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "//not-present tsg": "",
-            "odu-type-list": "[ ODU4 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "//not-present tsg": "",
+              "odu-type-list": "[ ODU4 ]",
+              "// default priority": 7
+            },
             "// tpn-range": 1,
             "// comment": "Since no TS range and no TSG are reported\
 \ for ODU4, the link is an OTU4 Link. TS allocation is not needed an\
@@ -215,21 +246,25 @@
           {
             "index ": 2,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1\
-\, ODU2, ODU2e, ODU3 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, OD\
+\U1, ODU2, ODU2e, ODU3 ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-80"
           },
           {
             "index ": 3,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-1.25G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1\
-\, ODU2, ODU2e, ODU3 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-1.25G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, OD\
+\U1, ODU2, ODU2e, ODU3 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-80",
             "// comment": "Since this TPN range is reported for any \
 \LO-ODUj with 1.25G TSG, the TPN assignment rule is flexible within \
@@ -246,11 +281,13 @@
           {
             "index ": 1,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-slot",
-            "tsg": "tsg-5G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1\
-\, ODU2, ODU2e, ODU3, ODU4 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-slot",
+              "tsg": "tsg-5G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, OD\
+\U1, ODU2, ODU2e, ODU3, ODU4 ]",
+              "// default priority": 7
+            },
             "// ts-range": "1-20",
             "// comment": "Since the TS range is specified for any O\
 \DUk, the OTN Link is an ODUCn Link."
@@ -258,11 +295,13 @@
           {
             "index ": 2,
             "// default restriction": "inclusive",
-            "range-type": "label-range-trib-port",
-            "tsg": "tsg-5G",
-            "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, ODU1\
-\, ODU2, ODU2e, ODU3, ODU4 ]",
-            "// default priority": 7,
+            "otn-label-range": {
+              "range-type": "label-range-trib-port",
+              "tsg": "tsg-5G",
+              "odu-type-list": "[ ODUFlex-cbr, ODUFlex-gfp, ODU0, OD\
+\U1, ODU2, ODU2e, ODU3, ODU4 ]",
+              "// default priority": 7
+            },
             "// tpn-range": "1-10",
             "// comment": "Since this TPN range is reported for any \
 \ODUk with 5G TSG, the TPN assignment rule is flexible within a comm\


### PR DESCRIPTION
Updated layer1-types YANG:
- Added container for otn label hop: fix #99
- Fixed some issues with line length exceeding the 69 characters
- Added container for otn-link-bandwidth, otn-label-range-info, otn-label-start-end and otn-label-step: fix #98 

Uploaded JSON examples: fix #96 :
- Uploaded odu-label-restrictions-examples.json file
- Updated with the new conventions for comments in JSON files
- Created odu-label-restrictions-examples.txt by running rfcfold script

JSON examples aligned with the latest YANG model changes